### PR TITLE
 Translation :: Change：Name->名称

### DIFF
--- a/src/assets/lang/zh_CN.json
+++ b/src/assets/lang/zh_CN.json
@@ -38,7 +38,7 @@
   "Password error!": "密码错误！",
   "Account": "用户",
   "Logout": "退出账户",
-  "Name": "用户名",
+  "Name": "名称",
   "Password": "密码",
   "Change name": "更改用户名",
   "Change Password": "更改密码",


### PR DESCRIPTION
在文件管理器列表视图中，文件名列表头显示“用户名”，参考windows文件管理器改为“名称”更符合通用场景