### PR TITLE
:bug: When there is no explicit scheme specified in compose, the conf…

### DIFF
--- a/main/src/components/Apps/ComposeConfig.vue
+++ b/main/src/components/Apps/ComposeConfig.vue
@@ -294,7 +294,7 @@ export default {
 				},
 				"x-casaos": {
 					hostname: "",
-					scheme: "https",
+					scheme: "http",
 					index: "/",
 					port_map: "3000",
 					// name: "",


### PR DESCRIPTION
…iguration UI defaults to https, causing the saved address to fail to redirect correctly; this also causes the web port check of the application to fail.

refer to 2023-04-28