### PR TITLE
fix: add space between two buttons

### DIFF
--- a/src/assets/scss/common/_modal.scss
+++ b/src/assets/scss/common/_modal.scss
@@ -138,6 +138,7 @@
 
   .modal-card-foot {
     padding: 0.75rem 1.5rem 1.5rem 1.5rem;
+    gap: 1rem;
 
     .button {
       border-radius: 9999px;


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/29306285/236454856-fd28a9a0-c3a2-4bf5-90a4-420724081bb9.png)


After
![image](https://user-images.githubusercontent.com/29306285/236454664-3ce0dfe8-cddf-473a-b4ed-2d6bdf1d6e45.png)
