### PR TITLE
Add zoom screenshot image on click functionality

### DIFF
--- a/license
+++ b/license
@@ -1,0 +1,11872 @@
+├─ @achrinza/node-ipc@9.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/achrinza/node-ipc
+│  ├─ publisher: Brandon Nozaki Miller
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@achrinza/node-ipc
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@achrinza/node-ipc/licence
+├─ @ampproject/remapping@2.2.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/ampproject/remapping
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: jridgewell@google.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@ampproject/remapping
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@ampproject/remapping/LICENSE
+├─ @babel/code-frame@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/code-frame
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/code-frame/LICENSE
+├─ @babel/compat-data@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/compat-data
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/compat-data/LICENSE
+├─ @babel/core@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/core
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/core/LICENSE
+├─ @babel/generator@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/generator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/generator/LICENSE
+├─ @babel/helper-annotate-as-pure@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-annotate-as-pure
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-annotate-as-pure/LICENSE
+├─ @babel/helper-builder-binary-assignment-operator-visitor@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-builder-binary-assignment-operator-visitor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-builder-binary-assignment-operator-visitor/LICENSE
+├─ @babel/helper-compilation-targets@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-compilation-targets
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-compilation-targets/LICENSE
+├─ @babel/helper-create-class-features-plugin@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-create-class-features-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-create-class-features-plugin/LICENSE
+├─ @babel/helper-create-regexp-features-plugin@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-create-regexp-features-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-create-regexp-features-plugin/LICENSE
+├─ @babel/helper-define-polyfill-provider@0.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-polyfills
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-define-polyfill-provider
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-define-polyfill-provider/LICENSE
+├─ @babel/helper-environment-visitor@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-environment-visitor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-environment-visitor/LICENSE
+├─ @babel/helper-function-name@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-function-name
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-function-name/LICENSE
+├─ @babel/helper-hoist-variables@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-hoist-variables
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-hoist-variables/LICENSE
+├─ @babel/helper-member-expression-to-functions@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-member-expression-to-functions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-member-expression-to-functions/LICENSE
+├─ @babel/helper-module-imports@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-module-imports
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-module-imports/LICENSE
+├─ @babel/helper-module-transforms@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-module-transforms
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-module-transforms/LICENSE
+├─ @babel/helper-optimise-call-expression@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-optimise-call-expression
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-optimise-call-expression/LICENSE
+├─ @babel/helper-plugin-utils@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-plugin-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-plugin-utils/LICENSE
+├─ @babel/helper-remap-async-to-generator@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-remap-async-to-generator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-remap-async-to-generator/LICENSE
+├─ @babel/helper-replace-supers@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-replace-supers
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-replace-supers/LICENSE
+├─ @babel/helper-simple-access@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-simple-access
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-simple-access/LICENSE
+├─ @babel/helper-skip-transparent-expression-wrappers@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-skip-transparent-expression-wrappers
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-skip-transparent-expression-wrappers/LICENSE
+├─ @babel/helper-split-export-declaration@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-split-export-declaration
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-split-export-declaration/LICENSE
+├─ @babel/helper-string-parser@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-string-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-string-parser/LICENSE
+├─ @babel/helper-validator-identifier@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-validator-identifier
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-validator-identifier/LICENSE
+├─ @babel/helper-validator-option@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-validator-option
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-validator-option/LICENSE
+├─ @babel/helper-wrap-function@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-wrap-function
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helper-wrap-function/LICENSE
+├─ @babel/helpers@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helpers
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/helpers/LICENSE
+├─ @babel/highlight@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/highlight
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/highlight/LICENSE
+├─ @babel/parser@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/parser/LICENSE
+├─ @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/LICENSE
+├─ @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/LICENSE
+├─ @babel/plugin-proposal-class-properties@7.18.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-class-properties
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-class-properties/LICENSE
+├─ @babel/plugin-proposal-decorators@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-decorators
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-decorators/LICENSE
+├─ @babel/plugin-proposal-export-namespace-from@7.18.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-export-namespace-from
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-export-namespace-from/LICENSE
+├─ @babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-plugin-proposal-private-property-in-object
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-private-property-in-object
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-private-property-in-object/LICENSE
+├─ @babel/plugin-proposal-unicode-property-regex@7.18.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-unicode-property-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-proposal-unicode-property-regex/LICENSE
+├─ @babel/plugin-syntax-async-generators@7.8.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-async-generators
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-async-generators/LICENSE
+├─ @babel/plugin-syntax-class-properties@7.12.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-class-properties
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-class-properties/LICENSE
+├─ @babel/plugin-syntax-class-static-block@7.14.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-class-static-block
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-class-static-block/LICENSE
+├─ @babel/plugin-syntax-decorators@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-decorators
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-decorators/LICENSE
+├─ @babel/plugin-syntax-dynamic-import@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-dynamic-import
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-dynamic-import/LICENSE
+├─ @babel/plugin-syntax-export-namespace-from@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-export-namespace-from
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-export-namespace-from/LICENSE
+├─ @babel/plugin-syntax-import-assertions@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-import-assertions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-import-assertions/LICENSE
+├─ @babel/plugin-syntax-import-attributes@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-import-attributes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-import-attributes/LICENSE
+├─ @babel/plugin-syntax-import-meta@7.10.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-import-meta
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-import-meta/LICENSE
+├─ @babel/plugin-syntax-json-strings@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-json-strings
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-json-strings/LICENSE
+├─ @babel/plugin-syntax-jsx@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-jsx
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-jsx/LICENSE
+├─ @babel/plugin-syntax-logical-assignment-operators@7.10.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-logical-assignment-operators
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-logical-assignment-operators/LICENSE
+├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-nullish-coalescing-operator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-nullish-coalescing-operator/LICENSE
+├─ @babel/plugin-syntax-numeric-separator@7.10.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-numeric-separator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-numeric-separator/LICENSE
+├─ @babel/plugin-syntax-object-rest-spread@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-object-rest-spread
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-object-rest-spread/LICENSE
+├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-optional-catch-binding
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-optional-catch-binding/LICENSE
+├─ @babel/plugin-syntax-optional-chaining@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-optional-chaining
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-optional-chaining/LICENSE
+├─ @babel/plugin-syntax-private-property-in-object@7.14.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-private-property-in-object
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-private-property-in-object/LICENSE
+├─ @babel/plugin-syntax-top-level-await@7.14.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-top-level-await
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-top-level-await/LICENSE
+├─ @babel/plugin-syntax-typescript@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-typescript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-typescript/LICENSE
+├─ @babel/plugin-syntax-unicode-sets-regex@7.18.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-unicode-sets-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-syntax-unicode-sets-regex/LICENSE
+├─ @babel/plugin-transform-arrow-functions@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-arrow-functions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-arrow-functions/LICENSE
+├─ @babel/plugin-transform-async-generator-functions@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-async-generator-functions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-async-generator-functions/LICENSE
+├─ @babel/plugin-transform-async-to-generator@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-async-to-generator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-async-to-generator/LICENSE
+├─ @babel/plugin-transform-block-scoped-functions@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-block-scoped-functions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-block-scoped-functions/LICENSE
+├─ @babel/plugin-transform-block-scoping@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-block-scoping
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-block-scoping/LICENSE
+├─ @babel/plugin-transform-class-properties@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-class-properties
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-class-properties/LICENSE
+├─ @babel/plugin-transform-class-static-block@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-class-static-block
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-class-static-block/LICENSE
+├─ @babel/plugin-transform-classes@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-classes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-classes/LICENSE
+├─ @babel/plugin-transform-computed-properties@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-computed-properties
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-computed-properties/LICENSE
+├─ @babel/plugin-transform-destructuring@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-destructuring
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-destructuring/LICENSE
+├─ @babel/plugin-transform-dotall-regex@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-dotall-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-dotall-regex/LICENSE
+├─ @babel/plugin-transform-duplicate-keys@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-duplicate-keys
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-duplicate-keys/LICENSE
+├─ @babel/plugin-transform-dynamic-import@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-dynamic-import
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-dynamic-import/LICENSE
+├─ @babel/plugin-transform-exponentiation-operator@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-exponentiation-operator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-exponentiation-operator/LICENSE
+├─ @babel/plugin-transform-export-namespace-from@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-export-namespace-from
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-export-namespace-from/LICENSE
+├─ @babel/plugin-transform-for-of@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-for-of
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-for-of/LICENSE
+├─ @babel/plugin-transform-function-name@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-function-name
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-function-name/LICENSE
+├─ @babel/plugin-transform-json-strings@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-json-strings
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-json-strings/LICENSE
+├─ @babel/plugin-transform-literals@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-literals
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-literals/LICENSE
+├─ @babel/plugin-transform-logical-assignment-operators@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-logical-assignment-operators
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-logical-assignment-operators/LICENSE
+├─ @babel/plugin-transform-member-expression-literals@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-member-expression-literals
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-member-expression-literals/LICENSE
+├─ @babel/plugin-transform-modules-amd@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-modules-amd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-modules-amd/LICENSE
+├─ @babel/plugin-transform-modules-commonjs@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-modules-commonjs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-modules-commonjs/LICENSE
+├─ @babel/plugin-transform-modules-systemjs@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-modules-systemjs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-modules-systemjs/LICENSE
+├─ @babel/plugin-transform-modules-umd@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-modules-umd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-modules-umd/LICENSE
+├─ @babel/plugin-transform-named-capturing-groups-regex@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-named-capturing-groups-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-named-capturing-groups-regex/LICENSE
+├─ @babel/plugin-transform-new-target@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-new-target
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-new-target/LICENSE
+├─ @babel/plugin-transform-nullish-coalescing-operator@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-nullish-coalescing-operator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-nullish-coalescing-operator/LICENSE
+├─ @babel/plugin-transform-numeric-separator@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-numeric-separator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-numeric-separator/LICENSE
+├─ @babel/plugin-transform-object-rest-spread@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-object-rest-spread
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-object-rest-spread/LICENSE
+├─ @babel/plugin-transform-object-super@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-object-super
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-object-super/LICENSE
+├─ @babel/plugin-transform-optional-catch-binding@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-optional-catch-binding
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-optional-catch-binding/LICENSE
+├─ @babel/plugin-transform-optional-chaining@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-optional-chaining
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-optional-chaining/LICENSE
+├─ @babel/plugin-transform-parameters@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-parameters
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-parameters/LICENSE
+├─ @babel/plugin-transform-private-methods@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-private-methods
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-private-methods/LICENSE
+├─ @babel/plugin-transform-private-property-in-object@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-private-property-in-object
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-private-property-in-object/LICENSE
+├─ @babel/plugin-transform-property-literals@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-property-literals
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-property-literals/LICENSE
+├─ @babel/plugin-transform-regenerator@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-regenerator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-regenerator/LICENSE
+├─ @babel/plugin-transform-reserved-words@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-reserved-words
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-reserved-words/LICENSE
+├─ @babel/plugin-transform-runtime@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-runtime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-runtime/LICENSE
+├─ @babel/plugin-transform-shorthand-properties@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-shorthand-properties
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-shorthand-properties/LICENSE
+├─ @babel/plugin-transform-spread@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-spread
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-spread/LICENSE
+├─ @babel/plugin-transform-sticky-regex@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-sticky-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-sticky-regex/LICENSE
+├─ @babel/plugin-transform-template-literals@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-template-literals
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-template-literals/LICENSE
+├─ @babel/plugin-transform-typeof-symbol@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-typeof-symbol
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-typeof-symbol/LICENSE
+├─ @babel/plugin-transform-typescript@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-typescript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-typescript/LICENSE
+├─ @babel/plugin-transform-unicode-escapes@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-unicode-escapes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-unicode-escapes/LICENSE
+├─ @babel/plugin-transform-unicode-property-regex@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-unicode-property-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-unicode-property-regex/LICENSE
+├─ @babel/plugin-transform-unicode-regex@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-unicode-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-unicode-regex/LICENSE
+├─ @babel/plugin-transform-unicode-sets-regex@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-unicode-sets-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/plugin-transform-unicode-sets-regex/LICENSE
+├─ @babel/preset-env@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/preset-env
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/preset-env/LICENSE
+├─ @babel/preset-modules@0.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/preset-modules
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/preset-modules
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/preset-modules/LICENSE
+├─ @babel/preset-typescript@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/preset-typescript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/preset-typescript/LICENSE
+├─ @babel/regjsgen@0.8.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bnjmnt4n/regjsgen
+│  ├─ publisher: Benjamin Tan
+│  ├─ url: https://ofcr.se/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/regjsgen
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/regjsgen/LICENSE-MIT.txt
+├─ @babel/runtime@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/runtime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/runtime/LICENSE
+├─ @babel/template@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/template
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/template/LICENSE
+├─ @babel/traverse@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/traverse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/traverse/LICENSE
+├─ @babel/types@7.22.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/types
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@babel/types/LICENSE
+├─ @braintree/sanitize-url@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/braintree/sanitize-url
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@braintree/sanitize-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@braintree/sanitize-url/LICENSE
+├─ @discoveryjs/json-ext@0.5.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/discoveryjs/json-ext
+│  ├─ publisher: Roman Dvornov
+│  ├─ email: rdvornov@gmail.com
+│  ├─ url: https://github.com/lahmatiy
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@discoveryjs/json-ext
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@discoveryjs/json-ext/LICENSE
+├─ @fontsource/roboto@4.5.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fontsource/fontsource
+│  ├─ publisher: Lotus
+│  ├─ email: declininglotus@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@fontsource/roboto
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@fontsource/roboto/README.md
+├─ @gar/promisify@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/wraithgar/gar-promisify
+│  ├─ publisher: Gar
+│  ├─ email: gar+npm@danger.computer
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@gar/promisify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@gar/promisify/LICENSE.md
+├─ @hapi/address@2.1.4
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/hapijs/address
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/address
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/address/LICENSE.md
+├─ @hapi/bourne@1.3.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/hapijs/bourne
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/bourne
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/bourne/LICENSE.md
+├─ @hapi/hoek@8.5.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/hapijs/hoek
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/hoek
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/hoek/LICENSE.md
+├─ @hapi/joi@15.1.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/hapijs/joi
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/joi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/joi/LICENSE.md
+├─ @hapi/topo@3.1.6
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/hapijs/topo
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/topo
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@hapi/topo/LICENSE.md
+├─ @icewhale/casaos-appmanagement-openapi@0.4.4-alpha16
+│  ├─ licenses: Apache-2.0
+│  ├─ publisher: casaos
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@icewhale/casaos-appmanagement-openapi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@icewhale/casaos-appmanagement-openapi/LICENSE
+├─ @intervolga/optimize-cssnano-plugin@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/intervolga/optimize-cssnano-plugin
+│  ├─ publisher: Shkarupa Alex
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@intervolga/optimize-cssnano-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@intervolga/optimize-cssnano-plugin/LICENSE
+├─ @isaacs/cliui@8.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/cliui
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/LICENSE.txt
+├─ @jridgewell/gen-mapping@0.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/gen-mapping
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/gen-mapping
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/gen-mapping/LICENSE
+├─ @jridgewell/resolve-uri@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/resolve-uri
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/resolve-uri
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/resolve-uri/LICENSE
+├─ @jridgewell/set-array@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/set-array
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/set-array
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/set-array/LICENSE
+├─ @jridgewell/source-map@0.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/source-map
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/source-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/source-map/LICENSE
+├─ @jridgewell/sourcemap-codec@1.4.14
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/sourcemap-codec
+│  ├─ publisher: Rich Harris
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec/LICENSE
+├─ @jridgewell/sourcemap-codec@1.4.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/sourcemap-codec
+│  ├─ publisher: Rich Harris
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/sourcemap-codec
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/sourcemap-codec/LICENSE
+├─ @jridgewell/trace-mapping@0.3.18
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/trace-mapping
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/trace-mapping
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@jridgewell/trace-mapping/LICENSE
+├─ @kangc/v-md-editor@1.7.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/code-farmer-i/vue-markdown-editor
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/LICENSE
+├─ @linaria/core@4.2.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/callstack/linaria
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@linaria/core
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@linaria/core/LICENSE
+├─ @linaria/logger@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/callstack/linaria
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@linaria/logger
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@linaria/logger/LICENSE
+├─ @linaria/tags@4.3.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/callstack/linaria
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@linaria/tags
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@linaria/tags/LICENSE
+├─ @linaria/utils@4.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/callstack/linaria
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@linaria/utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@linaria/utils/LICENSE
+├─ @mdi/font@6.9.96
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/Templarian/MaterialDesign-Webfont
+│  ├─ publisher: Austin Andrews
+│  ├─ url: http://twitter.com/templarian
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@mdi/font
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@mdi/font/LICENSE
+├─ @mrmlnc/readdir-enhanced@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bigstickcarpet/readdir-enhanced
+│  ├─ publisher: James Messinger
+│  ├─ url: http://bigstickcarpet.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@mrmlnc/readdir-enhanced
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@mrmlnc/readdir-enhanced/LICENSE
+├─ @node-ipc/js-queue@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/node-ipc/js-queue
+│  ├─ publisher: Brandon Nozaki Miller
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@node-ipc/js-queue
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@node-ipc/js-queue/licence.md
+├─ @nodelib/fs.stat@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@nodelib/fs.stat
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@nodelib/fs.stat/README.md
+├─ @npmcli/fs@1.1.1
+│  ├─ licenses: ISC
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression-webpack-plugin/node_modules/@npmcli/fs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression-webpack-plugin/node_modules/@npmcli/fs/LICENSE.md
+├─ @npmcli/fs@3.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/fs
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/fs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/fs/LICENSE.md
+├─ @npmcli/move-file@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/npm/move-file
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/move-file
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/move-file/LICENSE.md
+├─ @pkgjs/parseargs@0.11.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pkgjs/parseargs
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@pkgjs/parseargs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@pkgjs/parseargs/LICENSE
+├─ @polka/url@1.0.0-next.21
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/polka
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke@lukeed.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@polka/url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@polka/url/license
+├─ @popperjs/core@2.11.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/popperjs/popper-core
+│  ├─ publisher: Federico Zivolo
+│  ├─ email: federico.zivolo@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@popperjs/core
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@popperjs/core/LICENSE.md
+├─ @remirror/core-constants@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/remirror/remirror
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/core-constants
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/core-constants/LICENSE
+├─ @remirror/core-helpers@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/remirror/remirror
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/core-helpers
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/core-helpers/LICENSE
+├─ @remirror/types@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/remirror/remirror
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/types
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/types/LICENSE
+├─ @soda/friendly-errors-webpack-plugin@1.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sodatea/friendly-errors-webpack-plugin
+│  ├─ publisher: Geoffroy Warin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@soda/friendly-errors-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@soda/friendly-errors-webpack-plugin/LICENSE
+├─ @soda/get-current-script@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sodatea/get-current-script
+│  ├─ publisher: Haoqun Jiang
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@soda/get-current-script
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@soda/get-current-script/LICENSE
+├─ @tiptap/core@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/core
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/core/README.md
+├─ @tiptap/extension-blockquote@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-blockquote
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-blockquote/README.md
+├─ @tiptap/extension-bold@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-bold
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-bold/README.md
+├─ @tiptap/extension-bubble-menu@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-bubble-menu
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-bubble-menu/README.md
+├─ @tiptap/extension-bullet-list@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-bullet-list
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-bullet-list/README.md
+├─ @tiptap/extension-code-block@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-code-block
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-code-block/README.md
+├─ @tiptap/extension-code@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-code
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-code/README.md
+├─ @tiptap/extension-document@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-document
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-document/README.md
+├─ @tiptap/extension-dropcursor@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-dropcursor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-dropcursor/README.md
+├─ @tiptap/extension-floating-menu@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-floating-menu
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-floating-menu/README.md
+├─ @tiptap/extension-gapcursor@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-gapcursor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-gapcursor/README.md
+├─ @tiptap/extension-hard-break@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-hard-break
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-hard-break/README.md
+├─ @tiptap/extension-heading@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-heading
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-heading/README.md
+├─ @tiptap/extension-highlight@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-highlight
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-highlight/README.md
+├─ @tiptap/extension-history@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-history
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-history/README.md
+├─ @tiptap/extension-horizontal-rule@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-horizontal-rule
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-horizontal-rule/README.md
+├─ @tiptap/extension-italic@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-italic
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-italic/README.md
+├─ @tiptap/extension-list-item@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-list-item
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-list-item/README.md
+├─ @tiptap/extension-ordered-list@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-ordered-list
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-ordered-list/README.md
+├─ @tiptap/extension-paragraph@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-paragraph
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-paragraph/README.md
+├─ @tiptap/extension-strike@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-strike
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-strike/README.md
+├─ @tiptap/extension-text@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-text
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-text/README.md
+├─ @tiptap/extension-typography@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-typography
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/extension-typography/README.md
+├─ @tiptap/pm@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/pm
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/pm/README.md
+├─ @tiptap/starter-kit@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/starter-kit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/starter-kit/README.md
+├─ @tiptap/vue-2@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ueberdosis/tiptap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/vue-2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tiptap/vue-2/README.md
+├─ @tootallnate/once@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/once
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tootallnate/once
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@tootallnate/once/LICENSE
+├─ @trysound/sax@0.2.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/svg/sax
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@trysound/sax
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@trysound/sax/LICENSE
+├─ @types/body-parser@1.19.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/body-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/body-parser/LICENSE
+├─ @types/connect-history-api-fallback@1.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/connect-history-api-fallback
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/connect-history-api-fallback/LICENSE
+├─ @types/connect@3.4.35
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/connect
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/connect/LICENSE
+├─ @types/express-serve-static-core@4.17.35
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/express-serve-static-core
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/express-serve-static-core/LICENSE
+├─ @types/express@4.17.17
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/express
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/express/LICENSE
+├─ @types/glob@7.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/glob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/glob/LICENSE
+├─ @types/http-proxy@1.17.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/http-proxy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/http-proxy/LICENSE
+├─ @types/json-schema@7.0.12
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/json-schema
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/json-schema/LICENSE
+├─ @types/linkify-it@3.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/linkify-it
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/linkify-it/LICENSE
+├─ @types/markdown-it@12.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/markdown-it
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/markdown-it/LICENSE
+├─ @types/mdurl@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/mdurl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/mdurl/LICENSE
+├─ @types/mime@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/mime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/mime/LICENSE
+├─ @types/mime@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/serve-static/node_modules/@types/mime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/serve-static/node_modules/@types/mime/LICENSE
+├─ @types/minimatch@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/minimatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/minimatch/LICENSE
+├─ @types/minimist@1.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/minimist
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/minimist/LICENSE
+├─ @types/node@20.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/node
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/node/LICENSE
+├─ @types/normalize-package-data@2.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/normalize-package-data
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/normalize-package-data/LICENSE
+├─ @types/object.omit@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/object.omit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/object.omit/LICENSE
+├─ @types/object.pick@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/object.pick
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/object.pick/LICENSE
+├─ @types/q@1.5.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/q
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/q/LICENSE
+├─ @types/qs@6.9.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/qs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/qs/LICENSE
+├─ @types/range-parser@1.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/range-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/range-parser/LICENSE
+├─ @types/send@0.17.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/send
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/send/LICENSE
+├─ @types/serve-static@1.15.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/serve-static
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/serve-static/LICENSE
+├─ @types/socket.io-client@1.4.36
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/socket.io-client
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/socket.io-client/LICENSE
+├─ @types/source-list-map@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/source-list-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/source-list-map/LICENSE
+├─ @types/tapable@1.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/tapable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/tapable/LICENSE
+├─ @types/throttle-debounce@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/throttle-debounce
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/throttle-debounce/LICENSE
+├─ @types/uglify-js@3.17.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/uglify-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/uglify-js/LICENSE
+├─ @types/webpack-dev-server@3.11.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/webpack-dev-server
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/webpack-dev-server/LICENSE
+├─ @types/webpack-sources@3.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/webpack-sources
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/webpack-sources/LICENSE
+├─ @types/webpack@4.41.33
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/webpack
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/webpack/LICENSE
+├─ @vue/babel-helper-vue-jsx-merge-props@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx/tree/master/packages/babel-helper-vue-jsx-merge-props
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-helper-vue-jsx-merge-props
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-helper-vue-jsx-merge-props/README.md
+├─ @vue/babel-helper-vue-transform-on@1.0.2
+│  ├─ licenses: MIT
+│  ├─ publisher: Amour1688
+│  ├─ email: lcz_1996@foxmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-helper-vue-transform-on
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-helper-vue-transform-on/README.md
+├─ @vue/babel-plugin-jsx@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx-next
+│  ├─ publisher: Amour1688
+│  ├─ email: lcz_1996@foxmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-plugin-jsx
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-plugin-jsx/LICENSE
+├─ @vue/babel-plugin-transform-vue-jsx@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx/tree/master/packages/babel-plugin-transform-vue-jsx
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-plugin-transform-vue-jsx
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-plugin-transform-vue-jsx/README.md
+├─ @vue/babel-preset-app@4.5.19
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-preset-app
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-preset-app/LICENSE
+├─ @vue/babel-preset-jsx@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx/tree/master/packages/babel-preset-jsx
+│  ├─ publisher: Nick Messing
+│  ├─ email: dot.nick.dot.messing@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-preset-jsx
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-preset-jsx/README.md
+├─ @vue/babel-sugar-composition-api-inject-h@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx/tree/master/packages/babel-sugar-composition-api-inject-h
+│  ├─ publisher: luwanquan
+│  ├─ email: luwanquan@f-road.com.cn
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-composition-api-inject-h
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-composition-api-inject-h/README.md
+├─ @vue/babel-sugar-composition-api-render-instance@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx/tree/master/packages/babel-sugar-composition-api-render-instance
+│  ├─ publisher: luwanquan
+│  ├─ email: luwanquan@f-road.com.cn
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-composition-api-render-instance
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-composition-api-render-instance/README.md
+├─ @vue/babel-sugar-functional-vue@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx/tree/master/packages/babel-sugar-functional-vue
+│  ├─ publisher: Nick Messing
+│  ├─ email: dot.nick.dot.messing@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-functional-vue
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-functional-vue/README.md
+├─ @vue/babel-sugar-inject-h@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx/tree/master/packages/babel-sugar-inject-h
+│  ├─ publisher: Nick Messing
+│  ├─ email: dot.nick.dot.messing@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-inject-h
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-inject-h/README.md
+├─ @vue/babel-sugar-v-model@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx/tree/master/packages/babel-sugar-v-model
+│  ├─ publisher: Nick Messing
+│  ├─ email: dot.nick.dot.messing@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-v-model
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-v-model/README.md
+├─ @vue/babel-sugar-v-on@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/jsx/tree/master/packages/babel-sugar-v-on
+│  ├─ publisher: Nick Messing
+│  ├─ email: dot.nick.dot.messing@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-v-on
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-sugar-v-on/README.md
+├─ @vue/cli-overlay@4.5.19
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-overlay
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-overlay/LICENSE
+├─ @vue/cli-plugin-babel@4.5.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-babel
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-babel/LICENSE
+├─ @vue/cli-plugin-eslint@4.5.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/LICENSE
+├─ @vue/cli-plugin-router@4.5.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-router
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-router/LICENSE
+├─ @vue/cli-plugin-router@4.5.19
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@vue/cli-plugin-router
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@vue/cli-plugin-router/LICENSE
+├─ @vue/cli-plugin-vuex@4.5.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-vuex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-vuex/LICENSE
+├─ @vue/cli-plugin-vuex@4.5.19
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@vue/cli-plugin-vuex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@vue/cli-plugin-vuex/LICENSE
+├─ @vue/cli-service@4.5.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/LICENSE
+├─ @vue/cli-shared-utils@4.5.19
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-cli
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-shared-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-shared-utils/LICENSE
+├─ @vue/compiler-sfc@2.7.14
+│  ├─ licenses: MIT*
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/compiler-sfc
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/compiler-sfc/LICENSE
+├─ @vue/component-compiler-utils@3.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/component-compiler-utils
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils/README.md
+├─ @vue/preload-webpack-plugin@1.1.2
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/vuejs/preload-webpack-plugin
+│  ├─ publisher: Addy Osmani
+│  ├─ email: addy.osmani@gmail.com
+│  ├─ url: https://github.com/addyosmani
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@vue/preload-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@vue/preload-webpack-plugin/LICENSE
+├─ @vue/reactivity@3.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/core
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/reactivity
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/reactivity/LICENSE
+├─ @vue/runtime-core@3.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/core
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/runtime-core
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/runtime-core/LICENSE
+├─ @vue/runtime-dom@3.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/core
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/runtime-dom
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/runtime-dom/LICENSE
+├─ @vue/shared@3.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/core
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/shared
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/shared/LICENSE
+├─ @vue/web-component-wrapper@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/web-component-wrapper
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/web-component-wrapper
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/web-component-wrapper/README.md
+├─ @vuepress/markdown@1.9.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vuepress
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/README.md
+├─ @vuepress/shared-utils@1.9.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vuepress
+│  ├─ publisher: ULIVZ
+│  ├─ email: chl814@foxmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/shared-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/shared-utils/README.md
+├─ @webassemblyjs/ast@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/ast
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/ast/LICENSE
+├─ @webassemblyjs/ast@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/ast
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/ast/LICENSE
+├─ @webassemblyjs/floating-point-hex-parser@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Mauro Bringolf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/floating-point-hex-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/floating-point-hex-parser/LICENSE
+├─ @webassemblyjs/floating-point-hex-parser@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Mauro Bringolf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/floating-point-hex-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/floating-point-hex-parser/LICENSE
+├─ @webassemblyjs/helper-api-error@1.8.5
+│  ├─ licenses: MIT
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-api-error
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-api-error/LICENSE
+├─ @webassemblyjs/helper-api-error@1.9.0
+│  ├─ licenses: MIT
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-api-error
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-api-error/LICENSE
+├─ @webassemblyjs/helper-buffer@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-buffer/LICENSE
+├─ @webassemblyjs/helper-buffer@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-buffer/LICENSE
+├─ @webassemblyjs/helper-code-frame@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-code-frame
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-code-frame/LICENSE
+├─ @webassemblyjs/helper-code-frame@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-code-frame
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-code-frame/LICENSE
+├─ @webassemblyjs/helper-fsm@1.8.5
+│  ├─ licenses: ISC
+│  ├─ publisher: Mauro Bringolf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-fsm
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-fsm/LICENSE
+├─ @webassemblyjs/helper-fsm@1.9.0
+│  ├─ licenses: ISC
+│  ├─ publisher: Mauro Bringolf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-fsm
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-fsm/LICENSE
+├─ @webassemblyjs/helper-module-context@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-module-context
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-module-context/LICENSE
+├─ @webassemblyjs/helper-module-context@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-module-context
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-module-context/LICENSE
+├─ @webassemblyjs/helper-wasm-bytecode@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-wasm-bytecode
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-wasm-bytecode/LICENSE
+├─ @webassemblyjs/helper-wasm-bytecode@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-wasm-bytecode
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-wasm-bytecode/LICENSE
+├─ @webassemblyjs/helper-wasm-section@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-wasm-section
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/helper-wasm-section/LICENSE
+├─ @webassemblyjs/helper-wasm-section@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-wasm-section
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/helper-wasm-section/LICENSE
+├─ @webassemblyjs/ieee754@1.8.5
+│  ├─ licenses: MIT
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/ieee754
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/ieee754/LICENSE
+├─ @webassemblyjs/ieee754@1.9.0
+│  ├─ licenses: MIT
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/ieee754
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/ieee754/LICENSE
+├─ @webassemblyjs/leb128@1.8.5
+│  ├─ licenses: MIT
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/leb128
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/leb128/LICENSE.txt
+├─ @webassemblyjs/leb128@1.9.0
+│  ├─ licenses: MIT
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/leb128
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/leb128/LICENSE.txt
+├─ @webassemblyjs/utf8@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/utf8
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/utf8/LICENSE
+├─ @webassemblyjs/utf8@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/utf8
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/utf8/LICENSE
+├─ @webassemblyjs/wasm-edit@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wasm-edit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wasm-edit/LICENSE
+├─ @webassemblyjs/wasm-edit@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wasm-edit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wasm-edit/LICENSE
+├─ @webassemblyjs/wasm-gen@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wasm-gen
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wasm-gen/LICENSE
+├─ @webassemblyjs/wasm-gen@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wasm-gen
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wasm-gen/LICENSE
+├─ @webassemblyjs/wasm-opt@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wasm-opt
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wasm-opt/LICENSE
+├─ @webassemblyjs/wasm-opt@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wasm-opt
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wasm-opt/LICENSE
+├─ @webassemblyjs/wasm-parser@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wasm-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wasm-parser/LICENSE
+├─ @webassemblyjs/wasm-parser@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wasm-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wasm-parser/LICENSE
+├─ @webassemblyjs/wast-parser@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wast-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wast-parser/LICENSE
+├─ @webassemblyjs/wast-parser@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wast-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wast-parser/LICENSE
+├─ @webassemblyjs/wast-printer@1.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wast-printer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/node_modules/@webassemblyjs/wast-printer/LICENSE
+├─ @webassemblyjs/wast-printer@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wast-printer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webassemblyjs/wast-printer/LICENSE
+├─ @webpack-cli/configtest@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-cli
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webpack-cli/configtest
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webpack-cli/configtest/LICENSE
+├─ @webpack-cli/info@1.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-cli
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webpack-cli/info
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webpack-cli/info/LICENSE
+├─ @webpack-cli/serve@1.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-cli
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webpack-cli/serve
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@webpack-cli/serve/LICENSE
+├─ @xtuc/ieee754@1.2.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/feross/ieee754
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: http://feross.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@xtuc/ieee754
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@xtuc/ieee754/LICENSE
+├─ @xtuc/long@4.2.2
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/dcodeIO/long.js
+│  ├─ publisher: Daniel Wirtz
+│  ├─ email: dcode@dcode.io
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@xtuc/long
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@xtuc/long/LICENSE
+├─ JSV@4.0.2
+│  ├─ licenses: FreeBSD
+│  ├─ repository: https://github.com/garycourt/JSV
+│  ├─ publisher: Gary Court
+│  ├─ email: gary.court@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/JSV
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/JSV/README.md
+├─ abbrev@1.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/abbrev-js
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/abbrev
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/abbrev/LICENSE
+├─ accepts@1.3.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/accepts
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/accepts
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/accepts/LICENSE
+├─ acorn-jsx@5.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/acornjs/acorn-jsx
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/acorn-jsx
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/acorn-jsx/LICENSE
+├─ acorn-walk@7.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/acornjs/acorn
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/acorn-walk
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/acorn-walk/LICENSE
+├─ acorn-walk@8.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/acornjs/acorn
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-bundle-analyzer/node_modules/acorn-walk
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-bundle-analyzer/node_modules/acorn-walk/LICENSE
+├─ acorn@6.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/acornjs/acorn
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/acorn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/acorn/LICENSE
+├─ acorn@7.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/acornjs/acorn
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/espree/node_modules/acorn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/espree/node_modules/acorn/LICENSE
+├─ acorn@8.8.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/acornjs/acorn
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/acorn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/acorn/LICENSE
+├─ address@1.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/node-modules/address
+│  ├─ publisher: fengmk2
+│  ├─ email: fengmk2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/address
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/address/LICENSE.txt
+├─ after@0.8.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/after
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/after
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/after/LICENCE
+├─ agent-base@6.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/node-agent-base
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/agent-base
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/agent-base/README.md
+├─ agentkeepalive@4.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/node-modules/agentkeepalive
+│  ├─ publisher: fengmk2
+│  ├─ email: fengmk2@gmail.com
+│  ├─ url: https://github.com/fengmk2
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/agentkeepalive
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/agentkeepalive/LICENSE
+├─ aggregate-error@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/aggregate-error
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/aggregate-error
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/aggregate-error/license
+├─ ajv-errors@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/epoberezkin/ajv-errors
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ajv-errors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ajv-errors/LICENSE
+├─ ajv-keywords@3.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/epoberezkin/ajv-keywords
+│  ├─ publisher: Evgeny Poberezkin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ajv-keywords
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ajv-keywords/LICENSE
+├─ ajv@6.12.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ajv-validator/ajv
+│  ├─ publisher: Evgeny Poberezkin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ajv
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ajv/LICENSE
+├─ alphanum-sort@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TrySound/alphanum-sort
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/alphanum-sort
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/alphanum-sort/LICENSE
+├─ ansi-colors@3.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/doowb/ansi-colors
+│  ├─ publisher: Brian Woodward
+│  ├─ url: https://github.com/doowb
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-colors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-colors/LICENSE
+├─ ansi-escapes@3.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/ansi-escapes
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-escapes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-escapes/license
+├─ ansi-escapes@4.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/ansi-escapes
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/ansi-escapes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/ansi-escapes/license
+├─ ansi-html-community@0.0.8
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mahdyar/ansi-html-community
+│  ├─ publisher: mahdyar
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-html-community
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-html-community/LICENSE
+├─ ansi-regex@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/renderkid/node_modules/ansi-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/renderkid/node_modules/ansi-regex/license
+├─ ansi-regex@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-regex/license
+├─ ansi-regex@4.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ora/node_modules/ansi-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ora/node_modules/ansi-regex/license
+├─ ansi-regex@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-ansi/node_modules/ansi-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-ansi/node_modules/ansi-regex/license
+├─ ansi-regex@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/ansi-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/ansi-regex/license
+├─ ansi-styles@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/ansi-styles
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: http://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nomnom/node_modules/ansi-styles
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nomnom/node_modules/ansi-styles/readme.md
+├─ ansi-styles@3.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-styles
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chalk/node_modules/ansi-styles
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chalk/node_modules/ansi-styles/license
+├─ ansi-styles@4.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-styles
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-styles
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-styles/license
+├─ ansi-styles@6.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-styles
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/ansi-styles
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/ansi-styles/license
+├─ any-promise@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kevinbeaty/any-promise
+│  ├─ publisher: Kevin Beaty
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/any-promise
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/any-promise/LICENSE
+├─ anymatch@2.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/micromatch/anymatch
+│  ├─ publisher: Elan Shanker
+│  ├─ url: http://github.com/es128
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/anymatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/anymatch/LICENSE
+├─ anymatch@3.1.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/micromatch/anymatch
+│  ├─ publisher: Elan Shanker
+│  ├─ url: https://github.com/es128
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/anymatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/anymatch/LICENSE
+├─ apexcharts@3.41.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/apexcharts/apexcharts.js
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/apexcharts
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/apexcharts/LICENSE
+├─ aproba@1.2.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/iarna/aproba
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/aproba
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/aproba/LICENSE
+├─ aproba@2.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/iarna/aproba
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gauge/node_modules/aproba
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gauge/node_modules/aproba/LICENSE
+├─ arch@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/arch
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: https://feross.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arch/LICENSE
+├─ are-we-there-yet@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/are-we-there-yet
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/are-we-there-yet
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/are-we-there-yet/LICENSE.md
+├─ argparse@1.0.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodeca/argparse
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/argparse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/argparse/LICENSE
+├─ argparse@2.0.1
+│  ├─ licenses: Python-2.0
+│  ├─ repository: https://github.com/nodeca/argparse
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/argparse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/argparse/LICENSE
+├─ arr-diff@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/arr-diff
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arr-diff
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arr-diff/LICENSE
+├─ arr-flatten@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/arr-flatten
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arr-flatten
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arr-flatten/LICENSE
+├─ arr-union@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/arr-union
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arr-union
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arr-union/LICENSE
+├─ array-buffer-byte-length@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/array-buffer-byte-length
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-buffer-byte-length
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-buffer-byte-length/LICENSE
+├─ array-flatten@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/array-flatten
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-flatten
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-flatten/LICENSE
+├─ array-flatten@2.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/array-flatten
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bonjour/node_modules/array-flatten
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bonjour/node_modules/array-flatten/LICENSE
+├─ array-union@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/array-union
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-union
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-union/license
+├─ array-uniq@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/array-uniq
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-uniq
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-uniq/license
+├─ array-unique@0.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/array-unique
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-unique
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array-unique/LICENSE
+├─ array.prototype.reduce@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Array.prototype.reduce
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array.prototype.reduce
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/array.prototype.reduce/LICENSE
+├─ arraybuffer.slice@0.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rase-/arraybuffer.slice
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arraybuffer.slice
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/arraybuffer.slice/LICENCE
+├─ asn1.js@5.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/asn1.js
+│  ├─ publisher: Fedor Indutny
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/asn1.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/asn1.js/LICENSE
+├─ asn1@0.2.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/joyent/node-asn1
+│  ├─ publisher: Joyent
+│  ├─ url: joyent.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/asn1
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/asn1/LICENSE
+├─ assert-plus@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mcavage/node-assert-plus
+│  ├─ publisher: Mark Cavage
+│  ├─ email: mcavage@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/assert-plus
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/assert-plus/README.md
+├─ assert@1.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/browserify/commonjs-assert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/assert
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/assert/LICENSE
+├─ assign-symbols@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/assign-symbols
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/assign-symbols
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/assign-symbols/LICENSE
+├─ astral-regex@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kevva/astral-regex
+│  ├─ publisher: Kevin Mårtensson
+│  ├─ email: kevinmartensson@gmail.com
+│  ├─ url: github.com/kevva
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/astral-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/astral-regex/license
+├─ async-each@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/paulmillr/async-each
+│  ├─ publisher: Paul Miller
+│  ├─ url: https://paulmillr.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/async-each
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/async-each/LICENSE
+├─ async-limiter@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/strml/async-limiter
+│  ├─ publisher: Samuel Reed
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/async-limiter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/async-limiter/LICENSE
+├─ async@2.6.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/caolan/async
+│  ├─ publisher: Caolan McMahon
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/portfinder/node_modules/async
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/portfinder/node_modules/async/LICENSE
+├─ async@3.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/caolan/async
+│  ├─ publisher: Caolan McMahon
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/async
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/async/LICENSE
+├─ asynckit@0.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/alexindigo/asynckit
+│  ├─ publisher: Alex Indigo
+│  ├─ email: iam@alexindigo.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/asynckit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/asynckit/LICENSE
+├─ atob@2.1.2
+│  ├─ licenses: (MIT OR Apache-2.0)
+│  ├─ repository: git://git.coolaj86.com/coolaj86/atob.js
+│  ├─ publisher: AJ ONeal
+│  ├─ email: coolaj86@gmail.com
+│  ├─ url: https://coolaj86.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/atob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/atob/LICENSE
+├─ autoprefixer@9.8.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/autoprefixer
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/autoprefixer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/autoprefixer/LICENSE
+├─ available-typed-arrays@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/available-typed-arrays
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/available-typed-arrays
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/available-typed-arrays/LICENSE
+├─ aws-sign2@0.7.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mikeal/aws-sign
+│  ├─ publisher: Mikeal Rogers
+│  ├─ email: mikeal.rogers@gmail.com
+│  ├─ url: http://www.futurealoof.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/aws-sign2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/aws-sign2/LICENSE
+├─ aws4@1.12.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mhart/aws4
+│  ├─ publisher: Michael Hart
+│  ├─ email: michael.hart.au@gmail.com
+│  ├─ url: https://github.com/mhart
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/aws4
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/aws4/LICENSE
+├─ axios@0.26.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/axios/axios
+│  ├─ publisher: Matt Zabriskie
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/axios
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/axios/LICENSE
+├─ axios@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/axios/axios
+│  ├─ publisher: Matt Zabriskie
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@icewhale/casaos-appmanagement-openapi/node_modules/axios
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@icewhale/casaos-appmanagement-openapi/node_modules/axios/LICENSE
+├─ babel-eslint@10.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-eslint
+│  ├─ publisher: Sebastian McKenzie
+│  ├─ email: sebmck@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-eslint
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-eslint/LICENSE
+├─ babel-loader@8.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-loader
+│  ├─ publisher: Luis Couto
+│  ├─ email: hello@luiscouto.pt
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-babel/node_modules/babel-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-babel/node_modules/babel-loader/LICENSE
+├─ babel-merge@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/neutrinojs/babel-merge
+│  ├─ publisher: Eli Perelman
+│  ├─ email: eli@eliperelman.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-merge
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-merge/LICENSE
+├─ babel-plugin-dynamic-import-node@2.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/airbnb/babel-plugin-dynamic-import-node
+│  ├─ publisher: Jordan Gensler
+│  ├─ email: jordan.gensler@airbnb.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-dynamic-import-node
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-dynamic-import-node/LICENSE
+├─ babel-plugin-polyfill-corejs2@0.4.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-polyfills
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-polyfill-corejs2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-polyfill-corejs2/LICENSE
+├─ babel-plugin-polyfill-corejs3@0.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-polyfills
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-polyfill-corejs3
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-polyfill-corejs3/LICENSE
+├─ babel-plugin-polyfill-regenerator@0.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-polyfills
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-polyfill-regenerator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-polyfill-regenerator/LICENSE
+├─ babel-plugin-syntax-dynamic-import@6.18.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-syntax-dynamic-import
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-plugin-syntax-dynamic-import/README.md
+├─ backo2@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mokesmokes/backo
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/backo2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/backo2/Readme.md
+├─ balanced-match@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/balanced-match
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/balanced-match
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/balanced-match/LICENSE.md
+├─ base64-arraybuffer@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/niklasvh/base64-arraybuffer
+│  ├─ publisher: Niklas von Hertzen
+│  ├─ email: niklasvh@gmail.com
+│  ├─ url: http://hertzen.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/base64-arraybuffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/base64-arraybuffer/LICENSE-MIT
+├─ base64-js@1.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/beatgammit/base64-js
+│  ├─ publisher: T. Jameson Little
+│  ├─ email: t.jameson.little@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/base64-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/base64-js/LICENSE
+├─ base@0.11.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/node-base/base
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/base
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/base/LICENSE
+├─ batch@0.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/batch
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/batch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/batch/LICENSE
+├─ bcrypt-pbkdf@1.0.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/joyent/node-bcrypt-pbkdf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bcrypt-pbkdf
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bcrypt-pbkdf/LICENSE
+├─ bfj@6.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: git+https://gitlab.com/philbooth/bfj
+│  ├─ publisher: Phil Booth
+│  ├─ url: https://gitlab.com/philbooth
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bfj
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bfj/COPYING
+├─ big.js@3.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/MikeMcl/big.js
+│  ├─ publisher: Michael Mclaughlin
+│  ├─ email: M8ch88l@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin/node_modules/big.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin/node_modules/big.js/LICENCE
+├─ big.js@5.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/MikeMcl/big.js
+│  ├─ publisher: Michael Mclaughlin
+│  ├─ email: M8ch88l@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/big.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/big.js/LICENCE
+├─ binary-extensions@1.13.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/binary-extensions
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/binary-extensions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/binary-extensions/license
+├─ binary-extensions@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/binary-extensions
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/binary-extensions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/binary-extensions/license
+├─ bindings@1.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/node-bindings
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://tootallnate.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bindings
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bindings/LICENSE.md
+├─ blob@0.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webmodules/blob
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/blob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/blob/LICENSE
+├─ bluebird@3.7.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/petkaantonov/bluebird
+│  ├─ publisher: Petka Antonov
+│  ├─ email: petka_antonov@hotmail.com
+│  ├─ url: http://github.com/petkaantonov/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bluebird
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bluebird/LICENSE
+├─ bn.js@4.12.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/bn.js
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bn.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bn.js/LICENSE
+├─ bn.js@5.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/bn.js
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-sign/node_modules/bn.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-sign/node_modules/bn.js/LICENSE
+├─ body-parser@1.20.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/body-parser
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/body-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/body-parser/LICENSE
+├─ bonjour@3.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/watson/bonjour
+│  ├─ publisher: Thomas Watson Steen
+│  ├─ email: w@tson.dk
+│  ├─ url: https://twitter.com/wa7son
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bonjour
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bonjour/LICENSE
+├─ boolbase@1.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/fb55/boolbase
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/boolbase
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/boolbase/README.md
+├─ brace-expansion@1.1.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/brace-expansion
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/brace-expansion
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/brace-expansion/LICENSE
+├─ brace-expansion@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/brace-expansion
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/brace-expansion
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/brace-expansion/LICENSE
+├─ braces@2.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/braces
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch/node_modules/braces
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch/node_modules/braces/LICENSE
+├─ braces@3.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/braces
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/braces
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/braces/LICENSE
+├─ brorand@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/brorand
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/brorand
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/brorand/README.md
+├─ browser-info@1.3.0
+│  ├─ licenses: MIT*
+│  ├─ repository: https://github.com/stevelacy/browser-info
+│  ├─ publisher: Steve Lacy
+│  ├─ email: me@slacy.me
+│  ├─ url: http://slacy.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browser-info
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browser-info/LICENSE
+├─ browserify-aes@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/browserify-aes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-aes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-aes/LICENSE
+├─ browserify-cipher@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/browserify-cipher
+│  ├─ publisher: Calvin Metcalf
+│  ├─ email: calvin.metcalf@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-cipher
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-cipher/LICENSE
+├─ browserify-des@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/browserify-des
+│  ├─ publisher: Calvin Metcalf
+│  ├─ email: calvin.metcalf@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-des
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-des/license
+├─ browserify-rsa@4.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/browserify-rsa
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-rsa
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-rsa/LICENSE
+├─ browserify-sign@4.2.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/crypto-browserify/browserify-sign
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-sign
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-sign/LICENSE
+├─ browserify-zlib@0.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/devongovett/browserify-zlib
+│  ├─ publisher: Devon Govett
+│  ├─ email: devongovett@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-zlib
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserify-zlib/LICENSE
+├─ browserslist@4.21.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/browserslist/browserslist
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserslist
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/browserslist/LICENSE
+├─ buefy@0.9.23
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/buefy/buefy
+│  ├─ publisher: Rafael Beraldo
+│  ├─ email: rafael.pimpa@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buefy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buefy/LICENSE
+├─ buffer-from@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/LinusU/buffer-from
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer-from
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer-from/LICENSE
+├─ buffer-indexof@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/soldair/node-buffer-indexof
+│  ├─ publisher: Ryan Day
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer-indexof
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer-indexof/LICENSE
+├─ buffer-json@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jprichardson/buffer-json
+│  ├─ publisher: JP Richardson
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer-json
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer-json/README.md
+├─ buffer-xor@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/buffer-xor
+│  ├─ publisher: Daniel Cousens
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer-xor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer-xor/LICENSE
+├─ buffer@4.9.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/buffer
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: http://feross.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/buffer/LICENSE
+├─ builtin-status-codes@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bendrucker/builtin-status-codes
+│  ├─ publisher: Ben Drucker
+│  ├─ email: bvdrucker@gmail.com
+│  ├─ url: bendrucker.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/builtin-status-codes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/builtin-status-codes/license
+├─ bulma@0.9.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jgthms/bulma
+│  ├─ publisher: Jeremy Thomas
+│  ├─ email: bbxdesign@gmail.com
+│  ├─ url: https://jgthms.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bulma
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bulma/LICENSE
+├─ bytes@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/bytes.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ url: http://tjholowaychuk.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression/node_modules/bytes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression/node_modules/bytes/LICENSE
+├─ bytes@3.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/bytes.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ url: http://tjholowaychuk.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bytes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/bytes/LICENSE
+├─ cacache@12.0.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/cacache
+│  ├─ publisher: Kat Marchán
+│  ├─ email: kzm@sykosomatic.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cacache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cacache/LICENSE.md
+├─ cacache@15.3.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/cacache
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression-webpack-plugin/node_modules/cacache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression-webpack-plugin/node_modules/cacache/LICENSE.md
+├─ cacache@17.1.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/cacache
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/cacache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/cacache/LICENSE.md
+├─ cache-base@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/cache-base
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cache-base
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cache-base/LICENSE
+├─ cache-loader@4.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/cache-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-babel/node_modules/cache-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-babel/node_modules/cache-loader/LICENSE
+├─ call-bind@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/call-bind
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/call-bind
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/call-bind/LICENSE
+├─ call-me-maybe@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/limulus/call-me-maybe
+│  ├─ publisher: Eric McCarthy
+│  ├─ email: eric@limulus.net
+│  ├─ url: http://www.limulus.net/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/call-me-maybe
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/call-me-maybe/LICENSE
+├─ caller-callsite@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/caller-callsite
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caller-callsite
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caller-callsite/license
+├─ caller-path@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/caller-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caller-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caller-path/license
+├─ callsites@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/callsites
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caller-callsite/node_modules/callsites
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caller-callsite/node_modules/callsites/license
+├─ callsites@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/callsites
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/callsites
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/callsites/license
+├─ camel-case@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/camel-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/camel-case
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/camel-case/LICENSE
+├─ camelcase@5.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/camelcase
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/camelcase
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/camelcase/license
+├─ camelcase@6.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/camelcase
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-plugin-jsx/node_modules/camelcase
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-plugin-jsx/node_modules/camelcase/license
+├─ caniuse-api@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nyalab/caniuse-api
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caniuse-api
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caniuse-api/LICENSE
+├─ caniuse-lite@1.0.30001503
+│  ├─ licenses: CC-BY-4.0
+│  ├─ repository: https://github.com/browserslist/caniuse-lite
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caniuse-lite
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caniuse-lite/LICENSE
+├─ casaos-main@0.4.2
+│  ├─ licenses: UNLICENSED
+│  ├─ private: true
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/casaos-main
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/casaos-main/README.md
+├─ casaos@0.4.2
+│  ├─ licenses: UNLICENSED
+│  ├─ private: true
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/license
+├─ case-anything@2.1.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mesqueeb/case-anything
+│  ├─ publisher: Luca Ban - Mesqueeb
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/case-anything
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/case-anything/LICENSE
+├─ case-sensitive-paths-webpack-plugin@2.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Urthen/case-sensitive-paths-webpack-plugin
+│  ├─ publisher: Michael Pratt
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/case-sensitive-paths-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/case-sensitive-paths-webpack-plugin/LICENSE
+├─ caseless@0.12.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mikeal/caseless
+│  ├─ publisher: Mikeal Rogers
+│  ├─ email: mikeal.rogers@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caseless
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/caseless/LICENSE
+├─ chalk@0.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/chalk
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: http://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nomnom/node_modules/chalk
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nomnom/node_modules/chalk/readme.md
+├─ chalk@2.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/chalk
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chalk
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chalk/license
+├─ chalk@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/chalk
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@soda/friendly-errors-webpack-plugin/node_modules/chalk
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/@soda/friendly-errors-webpack-plugin/node_modules/chalk/license
+├─ chalk@4.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/chalk
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/chalk
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/chalk/license
+├─ chardet@0.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/runk/node-chardet
+│  ├─ publisher: Dmitry Shirokov
+│  ├─ email: deadrunk@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chardet
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chardet/LICENSE
+├─ check-types@8.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: git+https://gitlab.com/philbooth/check-types.js
+│  ├─ publisher: Phil Booth
+│  ├─ email: pmbooth@gmail.com
+│  ├─ url: https://philbooth.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/check-types
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/check-types/COPYING
+├─ chokidar@2.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/paulmillr/chokidar
+│  ├─ publisher: Paul Miller
+│  ├─ url: https://paulmillr.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/chokidar
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/chokidar/README.md
+├─ chokidar@3.5.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/paulmillr/chokidar
+│  ├─ publisher: Paul Miller
+│  ├─ url: https://paulmillr.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chokidar
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chokidar/LICENSE
+├─ chownr@1.1.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/chownr
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cacache/node_modules/chownr
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cacache/node_modules/chownr/LICENSE
+├─ chownr@2.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/chownr
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chownr
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chownr/LICENSE
+├─ chrome-trace-event@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/samccone/chrome-trace-event
+│  ├─ publisher: Trent Mick, Sam Saccone
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chrome-trace-event
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chrome-trace-event/LICENSE.txt
+├─ ci-info@1.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/watson/ci-info
+│  ├─ publisher: Thomas Watson Steen
+│  ├─ email: w@tson.dk
+│  ├─ url: https://twitter.com/wa7son
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ci-info
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ci-info/LICENSE
+├─ cipher-base@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/cipher-base
+│  ├─ publisher: Calvin Metcalf
+│  ├─ email: calvin.metcalf@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cipher-base
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cipher-base/LICENSE
+├─ class-utils@0.3.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/class-utils
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/class-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/class-utils/LICENSE
+├─ clean-css@4.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jakubpawlowicz/clean-css
+│  ├─ publisher: Jakub Pawlowicz
+│  ├─ email: contact@jakubpawlowicz.com
+│  ├─ url: http://twitter.com/jakubpawlowicz
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clean-css
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clean-css/LICENSE
+├─ clean-stack@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/clean-stack
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clean-stack
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clean-stack/license
+├─ cli-cursor@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/cli-cursor
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-cursor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-cursor/license
+├─ cli-cursor@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/cli-cursor
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/cli-cursor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/cli-cursor/license
+├─ cli-highlight@2.1.11
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/felixfbecker/cli-highlight
+│  ├─ publisher: Felix Becker
+│  ├─ email: felix.b@outlook.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-highlight
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-highlight/LICENSE.txt
+├─ cli-spinners@2.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/cli-spinners
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-spinners
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-spinners/license
+├─ cli-width@2.2.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/knownasilya/cli-width
+│  ├─ publisher: Ilya Radchenko
+│  ├─ email: knownasilya@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-width
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-width/LICENSE
+├─ cli-width@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/knownasilya/cli-width
+│  ├─ publisher: Ilya Radchenko
+│  ├─ email: knownasilya@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/cli-width
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/cli-width/LICENSE
+├─ cli@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/node-js-libs/cli
+│  ├─ publisher: Chris O'Hara
+│  ├─ email: cohara87@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli/README.md
+├─ clipboard-copy@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/clipboard-copy
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: https://feross.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clipboard-copy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clipboard-copy/LICENSE
+├─ clipboardy@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/clipboardy
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clipboardy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clipboardy/license
+├─ cliui@5.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/cliui
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/yargs/node_modules/cliui
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/yargs/node_modules/cliui/LICENSE.txt
+├─ cliui@6.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/cliui
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/cliui
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/cliui/LICENSE.txt
+├─ cliui@7.0.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/cliui
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cliui
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cliui/LICENSE.txt
+├─ clone-deep@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/clone-deep
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clone-deep
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clone-deep/LICENSE
+├─ clone@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pvorb/node-clone
+│  ├─ publisher: Paul Vorbach
+│  ├─ email: paul@vorba.ch
+│  ├─ url: http://paul.vorba.ch/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/defaults/node_modules/clone
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/defaults/node_modules/clone/LICENSE
+├─ clone@2.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pvorb/node-clone
+│  ├─ publisher: Paul Vorbach
+│  ├─ email: paul@vorba.ch
+│  ├─ url: http://paul.vorba.ch/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clone
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clone/LICENSE
+├─ coa@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/veged/coa
+│  ├─ publisher: Sergey Berezhnoy
+│  ├─ email: veged@ya.ru
+│  ├─ url: http://github.com/veged
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/coa
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/coa/LICENSE
+├─ codemirror@5.65.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/codemirror/CodeMirror
+│  ├─ publisher: Marijn Haverbeke
+│  ├─ email: marijn@haverbeke.berlin
+│  ├─ url: http://marijnhaverbeke.nl
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/codemirror
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/codemirror/LICENSE
+├─ collection-visit@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/collection-visit
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/collection-visit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/collection-visit/LICENSE
+├─ color-convert@1.9.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Qix-/color-convert
+│  ├─ publisher: Heather Arthur
+│  ├─ email: fayearthur@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-convert
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-convert/LICENSE
+├─ color-convert@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Qix-/color-convert
+│  ├─ publisher: Heather Arthur
+│  ├─ email: fayearthur@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-styles/node_modules/color-convert
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ansi-styles/node_modules/color-convert/LICENSE
+├─ color-name@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dfcreative/color-name
+│  ├─ publisher: DY
+│  ├─ email: dfcreative@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-convert/node_modules/color-name
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-convert/node_modules/color-name/LICENSE
+├─ color-name@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/colorjs/color-name
+│  ├─ publisher: DY
+│  ├─ email: dfcreative@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-name
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-name/LICENSE
+├─ color-string@1.9.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Qix-/color-string
+│  ├─ publisher: Heather Arthur
+│  ├─ email: fayearthur@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-string
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-string/LICENSE
+├─ color-support@1.1.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/color-support
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-support
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color-support/LICENSE
+├─ color@3.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Qix-/color
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/color/LICENSE
+├─ colord@2.9.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/omgovich/colord
+│  ├─ publisher: Vlad Shilov
+│  ├─ email: omgovich@ya.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/colord
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/colord/LICENSE.md
+├─ colorette@2.0.20
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jorgebucaran/colorette
+│  ├─ publisher: Jorge Bucaran
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/colorette
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/colorette/LICENSE.md
+├─ combined-stream@1.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/felixge/node-combined-stream
+│  ├─ publisher: Felix Geisendörfer
+│  ├─ email: felix@debuggable.com
+│  ├─ url: http://debuggable.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/combined-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/combined-stream/License
+├─ commander@2.17.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tj/commander.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/html-minifier/node_modules/commander
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/html-minifier/node_modules/commander/LICENSE
+├─ commander@2.19.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tj/commander.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uglify-js/node_modules/commander
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uglify-js/node_modules/commander/LICENSE
+├─ commander@2.20.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tj/commander.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/commander
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/commander/LICENSE
+├─ commander@7.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tj/commander.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-dsv/node_modules/commander
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-dsv/node_modules/commander/LICENSE
+├─ commander@8.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tj/commander.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/katex/node_modules/commander
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/katex/node_modules/commander/LICENSE
+├─ commander@9.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tj/commander.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/commander
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/commander/LICENSE
+├─ commondir@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/node-commondir
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/commondir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/commondir/LICENSE
+├─ component-bind@1.0.0
+│  ├─ licenses: MIT*
+│  ├─ repository: https://github.com/component/bind
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/component-bind
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/component-bind/Readme.md
+├─ component-emitter@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/component/emitter
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/component-emitter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/component-emitter/LICENSE
+├─ component-inherit@0.0.3
+│  ├─ licenses: MIT*
+│  ├─ repository: https://github.com/component/inherit
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/component-inherit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/component-inherit/Readme.md
+├─ composerize@1.2.0
+│  ├─ licenses: MIT
+│  └─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/composerize
+├─ compressible@2.0.18
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/compressible
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compressible
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compressible/LICENSE
+├─ compression-webpack-plugin@5.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/compression-webpack-plugin
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression-webpack-plugin/LICENSE
+├─ compression@1.7.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/compression
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression/LICENSE
+├─ concat-map@0.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/node-concat-map
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/concat-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/concat-map/LICENSE
+├─ concat-stream@1.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/maxogden/concat-stream
+│  ├─ publisher: Max Ogden
+│  ├─ email: max@maxogden.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/concat-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/concat-stream/LICENSE
+├─ connect-history-api-fallback@1.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bripkens/connect-history-api-fallback
+│  ├─ publisher: Ben Ripkens
+│  ├─ email: bripkens.dev@gmail.com
+│  ├─ url: http://bripkens.de
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/connect-history-api-fallback
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/connect-history-api-fallback/LICENSE
+├─ console-browserify@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/console-browserify
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/console-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/console-browserify/LICENCE
+├─ console-browserify@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/browserify/console-browserify
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser/node_modules/console-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser/node_modules/console-browserify/LICENCE
+├─ console-control-strings@1.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/iarna/console-control-strings
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/console-control-strings
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/console-control-strings/LICENSE
+├─ consolidate@0.15.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tj/consolidate.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/consolidate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/consolidate/Readme.md
+├─ constants-browserify@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/constants-browserify
+│  ├─ publisher: Julian Gruber
+│  ├─ email: julian@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/constants-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/constants-browserify/README.md
+├─ content-disposition@0.5.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/content-disposition
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/content-disposition
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/content-disposition/LICENSE
+├─ content-type@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/content-type
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/content-type
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/content-type/LICENSE
+├─ convert-source-map@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thlorenz/convert-source-map
+│  ├─ publisher: Thorsten Lorenz
+│  ├─ email: thlorenz@gmx.de
+│  ├─ url: http://thlorenz.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/convert-source-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/convert-source-map/LICENSE
+├─ cookie-signature@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/node-cookie-signature
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@learnboost.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cookie-signature
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cookie-signature/Readme.md
+├─ cookie@0.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/cookie
+│  ├─ publisher: Roman Shtylman
+│  ├─ email: shtylman@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cookie
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cookie/LICENSE
+├─ copy-concurrently@1.0.5
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/copy-concurrently
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/copy-concurrently
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/copy-concurrently/LICENSE
+├─ copy-descriptor@0.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/copy-descriptor
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/copy-descriptor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/copy-descriptor/LICENSE
+├─ copy-to-clipboard@3.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sudodoki/copy-to-clipboard
+│  ├─ publisher: sudodoki
+│  ├─ email: smd.deluzion@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/copy-to-clipboard
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/copy-to-clipboard/LICENSE
+├─ copy-webpack-plugin@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/copy-webpack-plugin
+│  ├─ publisher: Len Boyette
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/copy-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/copy-webpack-plugin/LICENSE
+├─ core-js-compat@3.31.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zloirock/core-js
+│  ├─ publisher: Denis Pushkarev
+│  ├─ email: zloirock@zloirock.ru
+│  ├─ url: http://zloirock.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/core-js-compat
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/core-js-compat/LICENSE
+├─ core-js@2.6.12
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zloirock/core-js
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/composerize/node_modules/core-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/composerize/node_modules/core-js/LICENSE
+├─ core-js@3.31.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zloirock/core-js
+│  ├─ publisher: Denis Pushkarev
+│  ├─ email: zloirock@zloirock.ru
+│  ├─ url: http://zloirock.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/core-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/core-js/LICENSE
+├─ core-util-is@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/isaacs/core-util-is
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/verror/node_modules/core-util-is
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/verror/node_modules/core-util-is/LICENSE
+├─ core-util-is@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/isaacs/core-util-is
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/core-util-is
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/core-util-is/LICENSE
+├─ cosmiconfig@5.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/davidtheclark/cosmiconfig
+│  ├─ publisher: David Clark
+│  ├─ email: david.dave.clark@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cosmiconfig
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cosmiconfig/LICENSE
+├─ create-ecdh@4.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/createECDH
+│  ├─ publisher: Calvin Metcalf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/create-ecdh
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/create-ecdh/LICENSE
+├─ create-hash@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/createHash
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/create-hash
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/create-hash/LICENSE
+├─ create-hmac@1.1.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/createHmac
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/create-hmac
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/create-hmac/LICENSE
+├─ crelt@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/marijnh/crelt
+│  ├─ publisher: Marijn Haverbeke
+│  ├─ email: marijn@haverbeke.berlin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/crelt
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/crelt/LICENSE
+├─ cross-spawn@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/IndigoUnited/node-cross-spawn
+│  ├─ publisher: IndigoUnited
+│  ├─ email: hello@indigounited.com
+│  ├─ url: http://indigounited.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie/node_modules/cross-spawn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie/node_modules/cross-spawn/LICENSE
+├─ cross-spawn@6.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/moxystudio/node-cross-spawn
+│  ├─ publisher: André Cruz
+│  ├─ email: andre@moxy.studio
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/execa/node_modules/cross-spawn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/execa/node_modules/cross-spawn/LICENSE
+├─ cross-spawn@7.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/moxystudio/node-cross-spawn
+│  ├─ publisher: André Cruz
+│  ├─ email: andre@moxy.studio
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn/LICENSE
+├─ crypto-browserify@3.12.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/crypto-browserify
+│  ├─ publisher: Dominic Tarr
+│  ├─ email: dominic.tarr@gmail.com
+│  ├─ url: dominictarr.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/crypto-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/crypto-browserify/LICENSE
+├─ css-color-names@0.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bahamas10/css-color-names
+│  ├─ publisher: Dave Eddy
+│  ├─ email: dave@daveeddy.com
+│  ├─ url: http://www.daveeddy.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-color-names
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-color-names/README.md
+├─ css-declaration-sorter@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Siilwyn/css-declaration-sorter
+│  ├─ publisher: Selwyn
+│  ├─ email: talk@selwyn.cc
+│  ├─ url: https://selwyn.cc/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-declaration-sorter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-declaration-sorter/license.md
+├─ css-declaration-sorter@6.4.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/Siilwyn/css-declaration-sorter
+│  ├─ publisher: Selwyn
+│  ├─ email: talk@selwyn.cc
+│  ├─ url: https://selwyn.cc/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/css-declaration-sorter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/css-declaration-sorter/license.md
+├─ css-loader@3.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/css-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/css-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/css-loader/LICENSE
+├─ css-select-base-adapter@0.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nrkn/css-select-base-adapter
+│  ├─ publisher: Nik Coughlin
+│  ├─ email: nrkn.com@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-select-base-adapter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-select-base-adapter/LICENSE
+├─ css-select@2.1.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/css-select
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo/node_modules/css-select
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo/node_modules/css-select/LICENSE
+├─ css-select@4.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/css-select
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-select
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-select/LICENSE
+├─ css-tree@1.0.0-alpha.37
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/csstree/csstree
+│  ├─ publisher: Roman Dvornov
+│  ├─ email: rdvornov@gmail.com
+│  ├─ url: https://github.com/lahmatiy
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo/node_modules/css-tree
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo/node_modules/css-tree/LICENSE
+├─ css-tree@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/csstree/csstree
+│  ├─ publisher: Roman Dvornov
+│  ├─ email: rdvornov@gmail.com
+│  ├─ url: https://github.com/lahmatiy
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-tree
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-tree/LICENSE
+├─ css-what@3.4.2
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/css-what
+│  ├─ publisher: Felix Böhm
+│  ├─ email: me@feedic.com
+│  ├─ url: http://feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-what
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-what/LICENSE
+├─ css-what@6.1.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/css-what
+│  ├─ publisher: Felix Böhm
+│  ├─ email: me@feedic.com
+│  ├─ url: http://feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-select/node_modules/css-what
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-select/node_modules/css-what/LICENSE
+├─ cssesc@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/cssesc
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssesc
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssesc/LICENSE-MIT.txt
+├─ cssfilter@0.0.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/leizongmin/js-css-filter
+│  ├─ publisher: Zongmin Lei
+│  ├─ email: leizongmin@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssfilter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssfilter/LICENSE
+├─ csslint@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/CSSLint/csslint
+│  ├─ publisher: Nicole Sullivan
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/csslint
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/csslint/LICENSE
+├─ cssnano-preset-default@4.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-preset-default
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-preset-default/LICENSE-MIT
+├─ cssnano-preset-default@5.2.14
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/cssnano-preset-default
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/cssnano-preset-default/LICENSE-MIT
+├─ cssnano-util-get-arguments@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-util-get-arguments
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-util-get-arguments/LICENSE-MIT
+├─ cssnano-util-get-match@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-util-get-match
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-util-get-match/LICENSE-MIT
+├─ cssnano-util-raw-cache@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-util-raw-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-util-raw-cache/LICENSE-MIT
+├─ cssnano-util-same-parent@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-util-same-parent
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-util-same-parent/LICENSE-MIT
+├─ cssnano-utils@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano-utils/LICENSE
+├─ cssnano@4.1.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cssnano/LICENSE-MIT
+├─ cssnano@5.1.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/cssnano
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/cssnano/LICENSE-MIT
+├─ csso@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/css/csso
+│  ├─ publisher: Sergey Kryzhanovsky
+│  ├─ email: skryzhanovsky@ya.ru
+│  ├─ url: https://github.com/afelix
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/csso
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/csso/LICENSE
+├─ csstype@3.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/frenic/csstype
+│  ├─ publisher: Fredrik Nicol
+│  ├─ email: fredrik.nicol@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/csstype
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/csstype/LICENSE
+├─ custom-event-polyfill@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kumarharsh/custom-event-polyfill
+│  ├─ publisher: Evan Krambuhl
+│  ├─ email: thekrambuhl@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/custom-event-polyfill
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/custom-event-polyfill/LICENSE
+├─ cyclist@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/cyclist
+│  ├─ publisher: Mathias Buus Madsen
+│  ├─ email: mathiasbuus@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cyclist
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cyclist/LICENSE
+├─ d3-array@1.2.4
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-array
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-array
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-array/LICENSE
+├─ d3-array@3.2.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-array
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-array
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-array/LICENSE
+├─ d3-axis@1.0.12
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-axis
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-axis
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-axis/LICENSE
+├─ d3-axis@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-axis
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-axis
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-axis/LICENSE
+├─ d3-brush@1.1.6
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-brush
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-brush
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-brush/LICENSE
+├─ d3-brush@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-brush
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-brush
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-brush/LICENSE
+├─ d3-chord@1.0.6
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-chord
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-chord
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-chord/LICENSE
+├─ d3-chord@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-chord
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-chord
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-chord/LICENSE
+├─ d3-collection@1.0.7
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-collection
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-collection
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-collection/LICENSE
+├─ d3-color@1.4.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-color
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-color
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-color/LICENSE
+├─ d3-color@3.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-color
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-color
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-color/LICENSE
+├─ d3-contour@1.3.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-contour
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-contour
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-contour/LICENSE
+├─ d3-contour@4.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-contour
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-contour
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-contour/LICENSE
+├─ d3-delaunay@6.0.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-delaunay
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-delaunay
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-delaunay/LICENSE
+├─ d3-dispatch@1.0.6
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-dispatch
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-dispatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-dispatch/LICENSE
+├─ d3-dispatch@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-dispatch
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-dispatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-dispatch/LICENSE
+├─ d3-drag@1.2.5
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-drag
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-drag
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-drag/LICENSE
+├─ d3-drag@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-drag
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-drag
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-drag/LICENSE
+├─ d3-dsv@1.2.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-dsv
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-dsv
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-dsv/LICENSE
+├─ d3-dsv@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-dsv
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-dsv
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-dsv/LICENSE
+├─ d3-ease@1.0.7
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-ease
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-ease
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-ease/LICENSE
+├─ d3-ease@3.0.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-ease
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-ease
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-ease/LICENSE
+├─ d3-fetch@1.2.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-fetch
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-fetch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-fetch/LICENSE
+├─ d3-fetch@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-fetch
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-fetch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-fetch/LICENSE
+├─ d3-force@1.2.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-force
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-force
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-force/LICENSE
+├─ d3-force@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-force
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-force
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-force/LICENSE
+├─ d3-format@1.4.5
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-format
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-format
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-format/LICENSE
+├─ d3-format@3.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-format
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-format
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-format/LICENSE
+├─ d3-geo@1.12.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-geo
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-geo
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-geo/LICENSE
+├─ d3-geo@3.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-geo
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-geo
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-geo/LICENSE
+├─ d3-hierarchy@1.1.9
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-hierarchy
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-hierarchy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-hierarchy/LICENSE
+├─ d3-hierarchy@3.1.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-hierarchy
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-hierarchy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-hierarchy/LICENSE
+├─ d3-interpolate@1.4.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-interpolate
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-interpolate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-interpolate/LICENSE
+├─ d3-interpolate@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-interpolate
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-interpolate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-interpolate/LICENSE
+├─ d3-path@1.0.9
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-path
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-path/LICENSE
+├─ d3-path@3.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-path
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-path/LICENSE
+├─ d3-polygon@1.0.6
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-polygon
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-polygon
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-polygon/LICENSE
+├─ d3-polygon@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-polygon
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-polygon
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-polygon/LICENSE
+├─ d3-quadtree@1.0.7
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-quadtree
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-quadtree
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-quadtree/LICENSE
+├─ d3-quadtree@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-quadtree
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-quadtree
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-quadtree/LICENSE
+├─ d3-random@1.1.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-random
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-random
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-random/LICENSE
+├─ d3-random@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-random
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-random
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-random/LICENSE
+├─ d3-scale-chromatic@1.5.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-scale-chromatic
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-scale-chromatic
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-scale-chromatic/LICENSE
+├─ d3-scale-chromatic@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-scale-chromatic
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-scale-chromatic
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-scale-chromatic/LICENSE
+├─ d3-scale@2.2.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-scale
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-scale
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-scale/LICENSE
+├─ d3-scale@4.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-scale
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-scale
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-scale/LICENSE
+├─ d3-selection@1.4.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-selection
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-selection
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-selection/LICENSE
+├─ d3-selection@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-selection
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-selection
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-selection/LICENSE
+├─ d3-shape@1.3.7
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-shape
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-shape
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-shape/LICENSE
+├─ d3-shape@3.2.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-shape
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-shape
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-shape/LICENSE
+├─ d3-time-format@2.3.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-time-format
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-time-format
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-time-format/LICENSE
+├─ d3-time-format@4.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-time-format
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-time-format
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-time-format/LICENSE
+├─ d3-time@1.1.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-time
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-time
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-time/LICENSE
+├─ d3-time@3.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-time
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-time
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-time/LICENSE
+├─ d3-timer@1.0.10
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-timer
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-timer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-timer/LICENSE
+├─ d3-timer@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-timer
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-timer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-timer/LICENSE
+├─ d3-transition@1.3.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-transition
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-transition
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-transition/LICENSE
+├─ d3-transition@3.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-transition
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-transition
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-transition/LICENSE
+├─ d3-voronoi@1.1.4
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-voronoi
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-voronoi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-voronoi/LICENSE
+├─ d3-zoom@1.8.3
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3-zoom
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-zoom
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3-zoom/LICENSE
+├─ d3-zoom@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3-zoom
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-zoom
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-zoom/LICENSE
+├─ d3@5.16.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/d3/d3
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/node_modules/d3/LICENSE
+├─ d3@7.8.5
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/d3/d3
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3/LICENSE
+├─ dagre-d3@0.6.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dagrejs/dagre-d3
+│  ├─ publisher: Chris Pettitt
+│  ├─ email: chris@samsarin.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre-d3/LICENSE
+├─ dagre@0.8.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dagrejs/dagre
+│  ├─ publisher: Chris Pettitt
+│  ├─ email: cpettitt@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dagre/LICENSE
+├─ dash-get@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/itsjonq/dash-get
+│  ├─ publisher: Jon Quach
+│  ├─ email: hello@jonquach.com
+│  ├─ url: https://jonquach.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dash-get
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dash-get/LICENSE
+├─ dashdash@1.14.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/trentm/node-dashdash
+│  ├─ publisher: Trent Mick
+│  ├─ email: trentm@gmail.com
+│  ├─ url: http://trentm.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dashdash
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dashdash/LICENSE.txt
+├─ date-now@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Colingo/date-now
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/date-now
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/date-now/LICENCE
+├─ dateformat@5.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/felixge/node-dateformat
+│  ├─ publisher: Steven Levithan
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dateformat
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dateformat/LICENSE
+├─ dayjs@1.11.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/iamkun/dayjs
+│  ├─ publisher: iamkun
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dayjs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dayjs/LICENSE
+├─ de-indent@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/yyx990803/de-indent
+│  ├─ publisher: Evan You
+│  └─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/de-indent
+├─ debug@2.6.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/debug
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon/node_modules/debug
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon/node_modules/debug/LICENSE
+├─ debug@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/debug
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socket.io-client/node_modules/debug
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socket.io-client/node_modules/debug/LICENSE
+├─ debug@3.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/debug
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/portfinder/node_modules/debug
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/portfinder/node_modules/debug/LICENSE
+├─ debug@4.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/debug-js/debug
+│  ├─ publisher: Josh Junon
+│  ├─ email: josh.junon@protonmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/debug
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/debug/LICENSE
+├─ decamelize@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/decamelize
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/decamelize
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/decamelize/license
+├─ decode-uri-component@0.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/SamVerschueren/decode-uri-component
+│  ├─ publisher: Sam Verschueren
+│  ├─ email: sam.verschueren@gmail.com
+│  ├─ url: github.com/SamVerschueren
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/decode-uri-component
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/decode-uri-component/license
+├─ deep-equal@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/node-deep-equal
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/deep-equal
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/deep-equal/LICENSE
+├─ deep-is@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thlorenz/deep-is
+│  ├─ publisher: Thorsten Lorenz
+│  ├─ email: thlorenz@gmx.de
+│  ├─ url: http://thlorenz.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/deep-is
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/deep-is/LICENSE
+├─ deepmerge@1.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/KyleAMathews/deepmerge
+│  ├─ publisher: Nick Fisher
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/deepmerge
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/deepmerge/license.txt
+├─ deepmerge@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/KyleAMathews/deepmerge
+│  ├─ publisher: Nick Fisher
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-merge/node_modules/deepmerge
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/babel-merge/node_modules/deepmerge/license.txt
+├─ deepmerge@4.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TehShrike/deepmerge
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/core-helpers/node_modules/deepmerge
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/core-helpers/node_modules/deepmerge/license.txt
+├─ default-gateway@4.2.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/silverwind/default-gateway
+│  ├─ publisher: silverwind
+│  ├─ email: me@silverwind.io
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/internal-ip/node_modules/default-gateway
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/internal-ip/node_modules/default-gateway/LICENSE
+├─ default-gateway@5.0.5
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/silverwind/default-gateway
+│  ├─ publisher: silverwind
+│  ├─ email: me@silverwind.io
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/LICENSE
+├─ defaults@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/node-defaults
+│  ├─ publisher: Elijah Insua
+│  ├─ email: tmpvar@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/defaults
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/defaults/LICENSE
+├─ define-properties@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/define-properties
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-properties
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-properties/LICENSE
+├─ define-property@0.2.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/define-property
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property/LICENSE
+├─ define-property@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/define-property
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/base/node_modules/define-property
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/base/node_modules/define-property/LICENSE
+├─ define-property@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/define-property
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-regex/node_modules/define-property
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-regex/node_modules/define-property/LICENSE
+├─ del@4.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/del
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/del
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/del/license
+├─ delaunator@5.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/mapbox/delaunator
+│  ├─ publisher: Vladimir Agafonkin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/delaunator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/delaunator/LICENSE
+├─ delayed-stream@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/felixge/node-delayed-stream
+│  ├─ publisher: Felix Geisendörfer
+│  ├─ email: felix@debuggable.com
+│  ├─ url: http://debuggable.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/delayed-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/delayed-stream/License
+├─ delegates@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/node-delegates
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/delegates
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/delegates/License
+├─ depd@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dougwilson/nodejs-depd
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index/node_modules/depd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index/node_modules/depd/LICENSE
+├─ depd@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dougwilson/nodejs-depd
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/depd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/depd/LICENSE
+├─ des.js@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/des.js
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/des.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/des.js/README.md
+├─ destroy@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stream-utils/destroy
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/destroy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/destroy/LICENSE
+├─ detect-node@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/iliakan/detect-node
+│  ├─ publisher: Ilya Kantor
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/detect-node
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/detect-node/LICENSE
+├─ diff-match-patch@1.0.5
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/JackuB/diff-match-patch
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/diff-match-patch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/diff-match-patch/LICENSE
+├─ diffie-hellman@5.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/diffie-hellman
+│  ├─ publisher: Calvin Metcalf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/diffie-hellman
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/diffie-hellman/LICENSE
+├─ dir-glob@2.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kevva/dir-glob
+│  ├─ publisher: Kevin Mårtensson
+│  ├─ email: kevinmartensson@gmail.com
+│  ├─ url: github.com/kevva
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dir-glob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dir-glob/license
+├─ dns-equal@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/watson/dns-equal
+│  ├─ publisher: Thomas Watson Steen
+│  ├─ email: w@tson.dk
+│  ├─ url: https://twitter.com/wa7son
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dns-equal
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dns-equal/LICENSE
+├─ dns-packet@1.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/dns-packet
+│  ├─ publisher: Mathias Buus
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dns-packet
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dns-packet/LICENSE
+├─ dns-txt@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/watson/dns-txt
+│  ├─ publisher: Thomas Watson Steen
+│  ├─ email: w@tson.dk
+│  ├─ url: https://twitter.com/wa7son
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dns-txt
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dns-txt/LICENSE
+├─ doctrine@3.0.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/eslint/doctrine
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/doctrine
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/doctrine/LICENSE
+├─ dom-converter@0.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/AriaMinaei/dom-converter
+│  ├─ publisher: Aria Minaei
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dom-converter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dom-converter/LICENSE
+├─ dom-serializer@0.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cheeriojs/dom-renderer
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dom-serializer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dom-serializer/LICENSE
+├─ dom-serializer@1.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cheeriojs/dom-renderer
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domutils/node_modules/dom-serializer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domutils/node_modules/dom-serializer/LICENSE
+├─ dom-walk@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/dom-walk
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dom-walk
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dom-walk/LICENCE
+├─ dom7@2.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nolimits4web/dom7
+│  ├─ publisher: Vladimir Kharlampidi
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dom7
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dom7/LICENSE
+├─ domain-browser@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bevry/domain-browser
+│  ├─ publisher: 2013+ Bevry Pty Ltd
+│  ├─ email: us@bevry.me
+│  ├─ url: http://bevry.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domain-browser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domain-browser/LICENSE.md
+├─ domelementtype@1.3.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/domelementtype
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/domelementtype
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/domelementtype/LICENSE
+├─ domelementtype@2.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/domelementtype
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domelementtype
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domelementtype/LICENSE
+├─ domhandler@2.3.0
+│  ├─ licenses: BSD*
+│  ├─ repository: https://github.com/fb55/DomHandler
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/domhandler
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/domhandler/LICENSE
+├─ domhandler@4.3.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/domhandler
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domhandler
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domhandler/LICENSE
+├─ dompurify@2.3.5
+│  ├─ licenses: (MPL-2.0 OR Apache-2.0)
+│  ├─ repository: https://github.com/cure53/DOMPurify
+│  ├─ publisher: Mario Heiderich
+│  ├─ email: mario@cure53.de
+│  ├─ url: https://cure53.de/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dompurify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dompurify/LICENSE
+├─ domutils@1.5.1
+│  ├─ licenses: BSD*
+│  ├─ repository: https://github.com/FB55/domutils
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/domutils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/domutils/LICENSE
+├─ domutils@1.7.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/FB55/domutils
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo/node_modules/domutils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo/node_modules/domutils/LICENSE
+├─ domutils@2.8.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/domutils
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domutils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/domutils/LICENSE
+├─ dot-prop@5.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/dot-prop
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dot-prop
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dot-prop/license
+├─ dotenv-expand@5.1.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ publisher: motdotla
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dotenv-expand
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dotenv-expand/LICENSE
+├─ dotenv@8.6.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/motdotla/dotenv
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dotenv
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/dotenv/LICENSE
+├─ duplexer@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/duplexer
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/duplexer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/duplexer/LICENCE
+├─ duplexify@3.7.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/duplexify
+│  ├─ publisher: Mathias Buus
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/duplexify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/duplexify/LICENSE
+├─ eastasianwidth@0.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/komagata/eastasianwidth
+│  ├─ publisher: Masaki Komagata
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eastasianwidth
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eastasianwidth/README.md
+├─ easy-stack@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/RIAEvangelist/easy-stack
+│  ├─ publisher: Brandon Nozaki Miller
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/easy-stack
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/easy-stack/licence.md
+├─ ecc-jsbn@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/quartzjer/ecc-jsbn
+│  ├─ publisher: Jeremie Miller
+│  ├─ email: jeremie@jabber.org
+│  ├─ url: http://jeremie.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ecc-jsbn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ecc-jsbn/LICENSE
+├─ ee-first@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonathanong/ee-first
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ee-first
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ee-first/LICENSE
+├─ ejs@2.7.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mde/ejs
+│  ├─ publisher: Matthew Eernisse
+│  ├─ email: mde@fleegix.org
+│  ├─ url: http://fleegix.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ejs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ejs/LICENSE
+├─ electron-to-chromium@1.4.430
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/kilian/electron-to-chromium
+│  ├─ publisher: Kilian Valkhof
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/electron-to-chromium
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/electron-to-chromium/LICENSE
+├─ elliptic@6.5.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/elliptic
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/elliptic
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/elliptic/README.md
+├─ emoji-regex@7.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/emoji-regex
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/emoji-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/emoji-regex/LICENSE-MIT.txt
+├─ emoji-regex@8.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/emoji-regex
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string-width/node_modules/emoji-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string-width/node_modules/emoji-regex/LICENSE-MIT.txt
+├─ emoji-regex@9.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/emoji-regex
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/emoji-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/emoji-regex/LICENSE-MIT.txt
+├─ emojis-list@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kikobeats/emojis-list
+│  ├─ publisher: Kiko Beats
+│  ├─ email: josefrancisco.verdu@gmail.com
+│  ├─ url: https://github.com/Kikobeats
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin/node_modules/emojis-list
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin/node_modules/emojis-list/LICENSE.md
+├─ emojis-list@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kikobeats/emojis-list
+│  ├─ publisher: Kiko Beats
+│  ├─ email: josefrancisco.verdu@gmail.com
+│  ├─ url: https://github.com/Kikobeats
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/emojis-list
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/emojis-list/LICENSE.md
+├─ encodeurl@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pillarjs/encodeurl
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/encodeurl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/encodeurl/LICENSE
+├─ encoding@0.1.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/andris9/encoding
+│  ├─ publisher: Andris Reinman
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/encoding
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/encoding/LICENSE
+├─ end-of-stream@1.4.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/end-of-stream
+│  ├─ publisher: Mathias Buus
+│  ├─ email: mathiasbuus@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/end-of-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/end-of-stream/LICENSE
+├─ engine.io-client@3.5.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/socketio/engine.io-client
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/engine.io-client
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/engine.io-client/LICENSE
+├─ engine.io-parser@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/socketio/engine.io-parser
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/engine.io-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/engine.io-parser/LICENSE
+├─ enhanced-resolve@4.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/enhanced-resolve
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/enhanced-resolve
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/enhanced-resolve/LICENSE
+├─ entities@1.0.0
+│  ├─ licenses: BSD*
+│  ├─ repository: https://github.com/fb55/node-entities
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/entities
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/entities/LICENSE
+├─ entities@1.1.2
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/entities
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/entities
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/entities/LICENSE
+├─ entities@2.1.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/entities
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/entities
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/entities/LICENSE
+├─ entities@2.2.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/entities
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/entities
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/entities/LICENSE
+├─ entities@3.0.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/entities
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it/node_modules/entities
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it/node_modules/entities/LICENSE
+├─ env-paths@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/env-paths
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/env-paths
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/env-paths/license
+├─ envinfo@7.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tabrindle/envinfo
+│  ├─ publisher: tabrindle@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/envinfo
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/envinfo/LICENSE
+├─ err-code@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/IndigoUnited/js-err-code
+│  ├─ publisher: IndigoUnited
+│  ├─ email: hello@indigounited.com
+│  ├─ url: http://indigounited.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/err-code
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/err-code/README.md
+├─ errno@0.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rvagg/node-errno
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/errno
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/errno/README.md
+├─ error-ex@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/qix-/node-error-ex
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/error-ex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/error-ex/LICENSE
+├─ error-stack-parser@2.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stacktracejs/error-stack-parser
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/error-stack-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/error-stack-parser/LICENSE
+├─ es-abstract@1.21.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-abstract
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/es-abstract
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/es-abstract/LICENSE
+├─ es-array-method-boxes-properly@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-array-method-boxes-properly
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/es-array-method-boxes-properly
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/es-array-method-boxes-properly/LICENSE
+├─ es-set-tostringtag@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/es-set-tostringtag
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/es-set-tostringtag
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/es-set-tostringtag/LICENSE
+├─ es-to-primitive@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-to-primitive
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/es-to-primitive
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/es-to-primitive/LICENSE
+├─ escalade@3.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/escalade
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke.edwards05@gmail.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/escalade
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/escalade/license
+├─ escape-html@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/component/escape-html
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/escape-html
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/escape-html/LICENSE
+├─ escape-string-regexp@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/escape-string-regexp
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/escape-string-regexp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/escape-string-regexp/license
+├─ escape-string-regexp@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/escape-string-regexp
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-trailing-node/node_modules/escape-string-regexp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-trailing-node/node_modules/escape-string-regexp/license
+├─ eslint-loader@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/eslint-loader
+│  ├─ publisher: Maxime Thirouin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/eslint-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/eslint-loader/LICENSE
+├─ eslint-plugin-vue@8.7.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/eslint-plugin-vue
+│  ├─ publisher: Toru Nagashima
+│  ├─ url: https://github.com/mysticatea
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-plugin-vue
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-plugin-vue/LICENSE
+├─ eslint-scope@4.0.3
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/eslint/eslint-scope
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-scope
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-scope/LICENSE
+├─ eslint-scope@5.1.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/eslint/eslint-scope
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint/node_modules/eslint-scope
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint/node_modules/eslint-scope/LICENSE
+├─ eslint-scope@7.2.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/eslint/eslint-scope
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-eslint-parser/node_modules/eslint-scope
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-eslint-parser/node_modules/eslint-scope/LICENSE
+├─ eslint-utils@1.4.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mysticatea/eslint-utils
+│  ├─ publisher: Toru Nagashima
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-utils/LICENSE
+├─ eslint-utils@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mysticatea/eslint-utils
+│  ├─ publisher: Toru Nagashima
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-plugin-vue/node_modules/eslint-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-plugin-vue/node_modules/eslint-utils/LICENSE
+├─ eslint-visitor-keys@1.3.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/eslint/eslint-visitor-keys
+│  ├─ publisher: Toru Nagashima
+│  ├─ url: https://github.com/mysticatea
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-visitor-keys
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-visitor-keys/LICENSE
+├─ eslint-visitor-keys@2.1.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/eslint/eslint-visitor-keys
+│  ├─ publisher: Toru Nagashima
+│  ├─ url: https://github.com/mysticatea
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-plugin-vue/node_modules/eslint-visitor-keys
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-plugin-vue/node_modules/eslint-visitor-keys/LICENSE
+├─ eslint-visitor-keys@3.4.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/eslint/eslint-visitor-keys
+│  ├─ publisher: Toru Nagashima
+│  ├─ url: https://github.com/mysticatea
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys/LICENSE
+├─ eslint@6.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eslint/eslint
+│  ├─ publisher: Nicholas C. Zakas
+│  ├─ email: nicholas+npm@nczconsulting.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint/LICENSE
+├─ espree@6.2.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/eslint/espree
+│  ├─ publisher: Nicholas C. Zakas
+│  ├─ email: nicholas+npm@nczconsulting.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/espree
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/espree/LICENSE
+├─ espree@9.5.2
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/eslint/espree
+│  ├─ publisher: Nicholas C. Zakas
+│  ├─ email: nicholas+npm@nczconsulting.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-eslint-parser/node_modules/espree
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-eslint-parser/node_modules/espree/LICENSE
+├─ esprima@4.0.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/jquery/esprima
+│  ├─ publisher: Ariya Hidayat
+│  ├─ email: ariya.hidayat@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/esprima
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/esprima/LICENSE.BSD
+├─ esquery@1.5.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/estools/esquery
+│  ├─ publisher: Joel Feenstra
+│  ├─ email: jrfeenst+esquery@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/esquery
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/esquery/license.txt
+├─ esrecurse@4.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/estools/esrecurse
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/esrecurse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/esrecurse/README.md
+├─ estraverse@4.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/estools/estraverse
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-scope/node_modules/estraverse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eslint-scope/node_modules/estraverse/LICENSE.BSD
+├─ estraverse@5.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/estools/estraverse
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/estraverse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/estraverse/LICENSE.BSD
+├─ esutils@2.0.3
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/estools/esutils
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/esutils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/esutils/LICENSE.BSD
+├─ etag@1.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/etag
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/etag
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/etag/LICENSE
+├─ event-pubsub@4.3.0
+│  ├─ licenses: Unlicense
+│  ├─ repository: https://github.com/RIAEvangelist/event-pubsub
+│  ├─ publisher: Brandon Nozaki Miller
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/event-pubsub
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/event-pubsub/LICENSE
+├─ eventemitter3@4.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/primus/eventemitter3
+│  ├─ publisher: Arnout Kazemier
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eventemitter3
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eventemitter3/LICENSE
+├─ events@3.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Gozala/events
+│  ├─ publisher: Irakli Gozalishvili
+│  ├─ email: rfobic@gmail.com
+│  ├─ url: http://jeditoolkit.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/events
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/events/LICENSE
+├─ eventsource@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/EventSource/eventsource
+│  ├─ publisher: Aslak Hellesøy
+│  ├─ email: aslak.hellesoy@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eventsource
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/eventsource/LICENSE
+├─ evp_bytestokey@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/EVP_BytesToKey
+│  ├─ publisher: Calvin Metcalf
+│  ├─ email: calvin.metcalf@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/evp_bytestokey
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/evp_bytestokey/LICENSE
+├─ execa@0.8.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/execa
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie/node_modules/execa
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie/node_modules/execa/license
+├─ execa@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/execa
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/execa
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/execa/license
+├─ execa@3.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/execa
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/execa
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/execa/license
+├─ exit@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cowboy/node-exit
+│  ├─ publisher: "Cowboy" Ben Alman
+│  ├─ url: http://benalman.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/exit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/exit/LICENSE-MIT
+├─ expand-brackets@2.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/expand-brackets
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/expand-brackets
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/expand-brackets/LICENSE
+├─ exponential-backoff@3.1.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/coveo/exponential-backoff
+│  ├─ publisher: Sami Sayegh
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/exponential-backoff
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/exponential-backoff/LICENSE
+├─ express@4.18.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/express
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/express
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/express/LICENSE
+├─ extend-shallow@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/extend-shallow
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch/node_modules/braces/node_modules/extend-shallow
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch/node_modules/braces/node_modules/extend-shallow/LICENSE
+├─ extend-shallow@3.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/extend-shallow
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/split-string/node_modules/extend-shallow
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/split-string/node_modules/extend-shallow/LICENSE
+├─ extend@3.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/justmoon/node-extend
+│  ├─ publisher: Stefan Thomas
+│  ├─ email: justmoon@members.fsf.org
+│  ├─ url: http://www.justmoon.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/extend
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/extend/LICENSE
+├─ external-editor@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mrkmg/node-external-editor
+│  ├─ publisher: Kevin Gravier
+│  ├─ email: kevin@mrkmg.com
+│  ├─ url: https://mrkmg.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/external-editor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/external-editor/LICENSE
+├─ extglob@2.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/extglob
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/extglob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/extglob/LICENSE
+├─ extsprintf@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/davepacheco/node-extsprintf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/extsprintf
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/extsprintf/LICENSE
+├─ extsprintf@1.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/davepacheco/node-extsprintf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/verror/node_modules/extsprintf
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/verror/node_modules/extsprintf/LICENSE
+├─ fast-deep-equal@3.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/epoberezkin/fast-deep-equal
+│  ├─ publisher: Evgeny Poberezkin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fast-deep-equal
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fast-deep-equal/LICENSE
+├─ fast-glob@2.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mrmlnc/fast-glob
+│  ├─ publisher: Denis Malinochkin
+│  ├─ url: canonium.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fast-glob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fast-glob/LICENSE
+├─ fast-json-stable-stringify@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/epoberezkin/fast-json-stable-stringify
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fast-json-stable-stringify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fast-json-stable-stringify/LICENSE
+├─ fast-levenshtein@2.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/hiddentao/fast-levenshtein
+│  ├─ publisher: Ramesh Nair
+│  ├─ email: ram@hiddentao.com
+│  ├─ url: http://www.hiddentao.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fast-levenshtein
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fast-levenshtein/LICENSE.md
+├─ fastest-levenshtein@1.0.16
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ka-weihe/fastest-levenshtein
+│  ├─ publisher: Kasper U. Weihe
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fastest-levenshtein
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fastest-levenshtein/LICENSE.md
+├─ faye-websocket@0.11.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/faye/faye-websocket-node
+│  ├─ publisher: James Coglan
+│  ├─ email: jcoglan@gmail.com
+│  ├─ url: http://jcoglan.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/faye-websocket
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/faye-websocket/LICENSE.md
+├─ figgy-pudding@3.5.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/figgy-pudding
+│  ├─ publisher: Kat Marchán
+│  ├─ email: kzm@sykosomatic.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/figgy-pudding
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/figgy-pudding/LICENSE.md
+├─ figures@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/figures
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/figures
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/figures/license
+├─ figures@3.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/figures
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/figures
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/figures/license
+├─ file-entry-cache@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/royriojas/file-entry-cache
+│  ├─ publisher: Roy Riojas
+│  ├─ url: http://royriojas.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/file-entry-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/file-entry-cache/LICENSE
+├─ file-loader@4.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/file-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/file-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/file-loader/LICENSE
+├─ file-saver@2.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eligrey/FileSaver.js
+│  ├─ publisher: Eli Grey
+│  ├─ email: me@eligrey.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/file-saver
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/file-saver/LICENSE.md
+├─ file-uri-to-path@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/file-uri-to-path
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/file-uri-to-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/file-uri-to-path/LICENSE
+├─ filesize@3.6.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/avoidwork/filesize.js
+│  ├─ publisher: Jason Mulligan
+│  ├─ email: jason.mulligan@avoidwork.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/filesize
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/filesize/LICENSE
+├─ fill-range@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/fill-range
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch/node_modules/fill-range
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch/node_modules/fill-range/LICENSE
+├─ fill-range@7.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/fill-range
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fill-range
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fill-range/LICENSE
+├─ finalhandler@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pillarjs/finalhandler
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/finalhandler
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/finalhandler/LICENSE
+├─ find-cache-dir@0.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jamestalmage/find-cache-dir
+│  ├─ publisher: James Talmage
+│  ├─ email: james@talmage.io
+│  ├─ url: github.com/jamestalmage
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache/node_modules/find-cache-dir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache/node_modules/find-cache-dir/license
+├─ find-cache-dir@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/avajs/find-cache-dir
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/find-cache-dir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/find-cache-dir/license
+├─ find-cache-dir@3.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/avajs/find-cache-dir
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-cache-dir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-cache-dir/license
+├─ find-up@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/find-up
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache/node_modules/find-up
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache/node_modules/find-up/license
+├─ find-up@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/find-up
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-up
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-up/license
+├─ find-up@4.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/find-up
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pkg-dir/node_modules/find-up
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pkg-dir/node_modules/find-up/license
+├─ flat-cache@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/royriojas/flat-cache
+│  ├─ publisher: Roy Riojas
+│  ├─ url: http://royriojas.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/flat-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/flat-cache/LICENSE
+├─ flatted@2.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/WebReflection/flatted
+│  ├─ publisher: Andrea Giammarchi
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/flatted
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/flatted/LICENSE
+├─ flush-write-stream@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/flush-write-stream
+│  ├─ publisher: Mathias Buus
+│  ├─ url: @mafintosh
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/flush-write-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/flush-write-stream/LICENSE
+├─ follow-redirects@1.15.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/follow-redirects/follow-redirects
+│  ├─ publisher: Ruben Verborgh
+│  ├─ email: ruben@verborgh.org
+│  ├─ url: https://ruben.verborgh.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/follow-redirects
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/follow-redirects/LICENSE
+├─ for-each@0.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/for-each
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/for-each
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/for-each/LICENSE
+├─ for-in@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/for-in
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/for-in
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/for-in/LICENSE
+├─ foreground-child@3.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/tapjs/foreground-child
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/foreground-child
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/foreground-child/LICENSE
+├─ forever-agent@0.6.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mikeal/forever-agent
+│  ├─ publisher: Mikeal Rogers
+│  ├─ email: mikeal.rogers@gmail.com
+│  ├─ url: http://www.futurealoof.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/forever-agent
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/forever-agent/LICENSE
+├─ form-data@2.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/form-data/form-data
+│  ├─ publisher: Felix Geisendörfer
+│  ├─ email: felix@debuggable.com
+│  ├─ url: http://debuggable.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/request/node_modules/form-data
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/request/node_modules/form-data/License
+├─ form-data@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/form-data/form-data
+│  ├─ publisher: Felix Geisendörfer
+│  ├─ email: felix@debuggable.com
+│  ├─ url: http://debuggable.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/form-data
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/form-data/License
+├─ forwarded@0.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/forwarded
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/forwarded
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/forwarded/LICENSE
+├─ fragment-cache@0.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/fragment-cache
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fragment-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fragment-cache/LICENSE
+├─ fresh@0.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/fresh
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ url: http://tjholowaychuk.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fresh
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fresh/LICENSE
+├─ from2@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/hughsk/from2
+│  ├─ publisher: Hugh Kennedy
+│  ├─ email: hughskennedy@gmail.com
+│  ├─ url: http://hughsk.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/from2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/from2/LICENSE.md
+├─ fs-extra@7.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jprichardson/node-fs-extra
+│  ├─ publisher: JP Richardson
+│  ├─ email: jprichardson@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fs-extra
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fs-extra/LICENSE
+├─ fs-minipass@2.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/fs-minipass
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fs-minipass
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fs-minipass/LICENSE
+├─ fs-minipass@3.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/fs-minipass
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/fs-minipass
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/fs-minipass/LICENSE
+├─ fs-write-stream-atomic@1.0.10
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/fs-write-stream-atomic
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fs-write-stream-atomic
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fs-write-stream-atomic/LICENSE
+├─ fs.realpath@1.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/fs.realpath
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fs.realpath
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fs.realpath/LICENSE
+├─ fsevents@1.2.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/strongloop/fsevents
+│  ├─ publisher: Philipp Dunkel
+│  ├─ email: pip@pipobscure.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/fsevents
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/fsevents/LICENSE
+├─ fsevents@2.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fsevents/fsevents
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fsevents
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/fsevents/LICENSE
+├─ function-bind@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/function-bind
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/function-bind
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/function-bind/LICENSE
+├─ function.prototype.name@1.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Function.prototype.name
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/function.prototype.name
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/function.prototype.name/LICENSE
+├─ functional-red-black-tree@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mikolalysenko/functional-red-black-tree
+│  ├─ publisher: Mikola Lysenko
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/functional-red-black-tree
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/functional-red-black-tree/LICENSE
+├─ functions-have-names@1.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/functions-have-names
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/functions-have-names
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/functions-have-names/LICENSE
+├─ gauge@4.0.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/gauge
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gauge
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gauge/LICENSE.md
+├─ gensync@1.0.0-beta.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/loganfsmyth/gensync
+│  ├─ publisher: Logan Smyth
+│  ├─ email: loganfsmyth@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gensync
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gensync/LICENSE
+├─ get-caller-file@2.0.5
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/stefanpenner/get-caller-file
+│  ├─ publisher: Stefan Penner
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-caller-file
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-caller-file/LICENSE.md
+├─ get-intrinsic@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/get-intrinsic
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-intrinsic
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-intrinsic/LICENSE
+├─ get-stream@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/get-stream
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie/node_modules/get-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie/node_modules/get-stream/license
+├─ get-stream@4.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/get-stream
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-stream/license
+├─ get-stream@5.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/get-stream
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/get-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/get-stream/license
+├─ get-symbol-description@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/get-symbol-description
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-symbol-description
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-symbol-description/LICENSE
+├─ get-value@2.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/get-value
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-value
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/get-value/LICENSE
+├─ getpass@0.1.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/arekinath/node-getpass
+│  ├─ publisher: Alex Wilson
+│  ├─ email: alex.wilson@joyent.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/getpass
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/getpass/LICENSE
+├─ glob-parent@3.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/es128/glob-parent
+│  ├─ publisher: Elan Shanker
+│  ├─ url: https://github.com/es128
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/glob-parent
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/glob-parent/LICENSE
+├─ glob-parent@5.1.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/gulpjs/glob-parent
+│  ├─ publisher: Gulp Team
+│  ├─ email: team@gulpjs.com
+│  ├─ url: https://gulpjs.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chokidar/node_modules/glob-parent
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chokidar/node_modules/glob-parent/LICENSE
+├─ glob-to-regexp@0.3.0
+│  ├─ licenses: BSD*
+│  ├─ repository: https://github.com/fitzgen/glob-to-regexp
+│  ├─ publisher: Nick Fitzgerald
+│  ├─ email: fitzgen@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/glob-to-regexp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/glob-to-regexp/README.md
+├─ glob@10.2.7
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-glob
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: https://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/glob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/glob/LICENSE
+├─ glob@7.2.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-glob
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/glob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/glob/LICENSE
+├─ global@4.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/global
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/global
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/global/LICENSE
+├─ globals@11.12.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/globals
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/globals
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/globals/license
+├─ globalthis@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/System.global
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/globalthis
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/globalthis/LICENSE
+├─ globby@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/globby
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/del/node_modules/globby
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/del/node_modules/globby/license
+├─ globby@7.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/globby
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/copy-webpack-plugin/node_modules/globby
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/copy-webpack-plugin/node_modules/globby/license
+├─ globby@9.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/globby
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/globby
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/globby/license
+├─ gopd@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/gopd
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gopd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gopd/LICENSE
+├─ graceful-fs@4.2.11
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-graceful-fs
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/graceful-fs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/graceful-fs/LICENSE
+├─ graphlib@2.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dagrejs/graphlib
+│  ├─ publisher: Chris Pettitt
+│  ├─ email: cpettitt@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/graphlib
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/graphlib/LICENSE
+├─ gray-matter@4.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/gray-matter
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gray-matter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gray-matter/LICENSE
+├─ gsap@3.12.1
+│  ├─ licenses: MIT*
+│  ├─ repository: https://github.com/greensock/GSAP
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gsap
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gsap/README.md
+├─ gzip-size@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/gzip-size
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/gzip-size
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/gzip-size/license
+├─ gzip-size@6.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/gzip-size
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gzip-size
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gzip-size/license
+├─ handle-thing@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/handle-thing
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/handle-thing
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/handle-thing/README.md
+├─ har-schema@2.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/ahmadnassri/har-schema
+│  ├─ publisher: Ahmad Nassri
+│  ├─ email: ahmad@ahmadnassri.com
+│  ├─ url: https://www.ahmadnassri.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/har-schema
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/har-schema/LICENSE
+├─ har-validator@5.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ahmadnassri/node-har-validator
+│  ├─ publisher: Ahmad Nassri
+│  ├─ email: ahmad@ahmadnassri.com
+│  ├─ url: https://www.ahmadnassri.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/har-validator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/har-validator/LICENSE
+├─ has-bigints@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/has-bigints
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-bigints
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-bigints/LICENSE
+├─ has-binary2@1.0.3
+│  ├─ licenses: MIT
+│  ├─ publisher: Kevin Roark
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-binary2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-binary2/LICENSE
+├─ has-color@0.1.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/has-color
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: http://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-color
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-color/readme.md
+├─ has-cors@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/component/has-cors
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-cors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-cors/Readme.md
+├─ has-flag@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/has-flag
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-flag
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-flag/license
+├─ has-flag@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/has-flag
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/has-flag
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/has-flag/license
+├─ has-property-descriptors@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/has-property-descriptors
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-property-descriptors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-property-descriptors/LICENSE
+├─ has-proto@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/has-proto
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-proto
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-proto/LICENSE
+├─ has-symbols@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/has-symbols
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-symbols
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-symbols/LICENSE
+├─ has-tostringtag@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/has-tostringtag
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-tostringtag
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-tostringtag/LICENSE
+├─ has-unicode@2.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/iarna/has-unicode
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-unicode
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-unicode/LICENSE
+├─ has-value@0.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/has-value
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unset-value/node_modules/has-value
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unset-value/node_modules/has-value/LICENSE
+├─ has-value@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/has-value
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-value
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-value/LICENSE
+├─ has-values@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/has-values
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unset-value/node_modules/has-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unset-value/node_modules/has-values/LICENSE
+├─ has-values@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/has-values
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-values/LICENSE
+├─ has@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tarruda/has
+│  ├─ publisher: Thiago de Arruda
+│  ├─ email: tpadilha84@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has/LICENSE-MIT
+├─ hash-base@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/hash-base
+│  ├─ publisher: Kirill Fomichev
+│  ├─ email: fanatid@ya.ru
+│  ├─ url: https://github.com/fanatid
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hash-base
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hash-base/LICENSE
+├─ hash-sum@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bevacqua/hash-sum
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hash-sum
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hash-sum/license
+├─ hash-sum@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bevacqua/hash-sum
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/hash-sum
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/hash-sum/license
+├─ hash.js@1.1.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/hash.js
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hash.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hash.js/README.md
+├─ he@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/he
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/he
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/he/LICENSE-MIT.txt
+├─ hex-color-regex@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/regexps/hex-color-regex
+│  ├─ publisher: Charlike Mike Reagent
+│  ├─ email: @tunnckoCore
+│  ├─ url: http://www.tunnckocore.tk
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hex-color-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hex-color-regex/LICENSE.md
+├─ highlight.js@10.7.3
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/highlightjs/highlight.js
+│  ├─ publisher: Ivan Sagalaev
+│  ├─ email: maniac@softwaremaniacs.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/highlight.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/highlight.js/LICENSE
+├─ hitbox-js@1.0.2
+│  ├─ licenses: ISC
+│  ├─ publisher: leoboyerbx
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hitbox-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hitbox-js/README.md
+├─ hmac-drbg@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/hmac-drbg
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hmac-drbg
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hmac-drbg/README.md
+├─ hoopy@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: git+https://gitlab.com/philbooth/hoopy
+│  ├─ publisher: Phil Booth
+│  ├─ email: pmbooth@gmail.com
+│  ├─ url: https://philbooth.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hoopy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hoopy/LICENSE
+├─ hosted-git-info@2.8.9
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/hosted-git-info
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hosted-git-info
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hosted-git-info/LICENSE
+├─ hpack.js@2.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/hpack.js
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hpack.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hpack.js/README.md
+├─ hsl-regex@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/regexps/hsl-regex
+│  ├─ publisher: John Otander
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hsl-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hsl-regex/LICENSE.md
+├─ hsla-regex@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/regexps/hsla-regex
+│  ├─ publisher: John Otander
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hsla-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hsla-regex/LICENSE.md
+├─ html-entities@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mdevils/node-html-entities
+│  ├─ publisher: Marat Dulin
+│  ├─ email: mdevils@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/html-entities
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/html-entities/LICENSE
+├─ html-minifier@3.5.21
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kangax/html-minifier
+│  ├─ publisher: Juriy "kangax" Zaytsev
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/html-minifier
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/html-minifier/LICENSE
+├─ html-tags@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/html-tags
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/html-tags
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/html-tags/license
+├─ html-tags@3.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/html-tags
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-plugin-jsx/node_modules/html-tags
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/babel-plugin-jsx/node_modules/html-tags/license
+├─ html-webpack-plugin@3.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jantimon/html-webpack-plugin
+│  ├─ publisher: Charles Blaxland
+│  ├─ email: charles.blaxland@gmail.com
+│  ├─ url: https://github.com/ampedandwired
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin/LICENSE
+├─ htmlhint@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/htmlhint/HTMLHint
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/LICENSE.md
+├─ htmlparser2@3.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fb55/htmlparser2
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/LICENSE
+├─ htmlparser2@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fb55/htmlparser2
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/renderkid/node_modules/htmlparser2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/renderkid/node_modules/htmlparser2/LICENSE
+├─ http-cache-semantics@4.1.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/kornelski/http-cache-semantics
+│  ├─ publisher: Kornel Lesiński
+│  ├─ email: kornel@geekhood.net
+│  ├─ url: https://kornel.ski/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-cache-semantics
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-cache-semantics/LICENSE
+├─ http-deceiver@1.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/http-deceiver
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-deceiver
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-deceiver/README.md
+├─ http-errors@1.6.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/http-errors
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index/node_modules/http-errors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index/node_modules/http-errors/LICENSE
+├─ http-errors@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/http-errors
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-errors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-errors/LICENSE
+├─ http-parser-js@0.5.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/creationix/http-parser-js
+│  ├─ publisher: Tim Caswell
+│  ├─ url: https://github.com/creationix
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-parser-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-parser-js/LICENSE.md
+├─ http-proxy-agent@5.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/node-http-proxy-agent
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-proxy-agent
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-proxy-agent/README.md
+├─ http-proxy-middleware@0.19.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chimurai/http-proxy-middleware
+│  ├─ publisher: Steven Chim
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/http-proxy-middleware
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/http-proxy-middleware/LICENSE
+├─ http-proxy-middleware@1.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chimurai/http-proxy-middleware
+│  ├─ publisher: Steven Chim
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-proxy-middleware
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-proxy-middleware/LICENSE
+├─ http-proxy@1.18.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/http-party/node-http-proxy
+│  ├─ publisher: Charlie Robbins
+│  ├─ email: charlie.robbins@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-proxy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-proxy/LICENSE
+├─ http-signature@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/joyent/node-http-signature
+│  ├─ publisher: Joyent, Inc
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-signature
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-signature/LICENSE
+├─ https-browserify@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/https-browserify
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/https-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/https-browserify/LICENSE
+├─ https-proxy-agent@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/node-https-proxy-agent
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/https-proxy-agent
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/https-proxy-agent/README.md
+├─ human-signals@1.1.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/ehmicky/human-signals
+│  ├─ publisher: ehmicky
+│  ├─ email: ehmicky@gmail.com
+│  ├─ url: https://github.com/ehmicky
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/human-signals
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/human-signals/LICENSE
+├─ humanize-ms@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/node-modules/humanize-ms
+│  ├─ publisher: dead-horse
+│  ├─ email: dead_horse@qq.com
+│  ├─ url: http://deadhorse.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/humanize-ms
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/humanize-ms/LICENSE
+├─ iconv-lite@0.4.24
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ashtuchkin/iconv-lite
+│  ├─ publisher: Alexander Shtuchkin
+│  ├─ email: ashtuchkin@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/iconv-lite
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/iconv-lite/LICENSE
+├─ iconv-lite@0.6.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ashtuchkin/iconv-lite
+│  ├─ publisher: Alexander Shtuchkin
+│  ├─ email: ashtuchkin@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-dsv/node_modules/iconv-lite
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/d3-dsv/node_modules/iconv-lite/LICENSE
+├─ icss-utils@4.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/css-modules/icss-utils
+│  ├─ publisher: Glen Maddern
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/icss-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/icss-utils/LICENSE.md
+├─ ieee754@1.2.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/feross/ieee754
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: https://feross.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ieee754
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ieee754/LICENSE
+├─ iferr@0.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/shesek/iferr
+│  ├─ publisher: Nadav Ivgi
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/iferr
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/iferr/LICENSE
+├─ ignore@3.3.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kaelzhang/node-ignore
+│  ├─ publisher: kael
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/ignore
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/ignore/README.md
+├─ ignore@4.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kaelzhang/node-ignore
+│  ├─ publisher: kael
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ignore
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ignore/LICENSE-MIT
+├─ immutable@4.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/immutable-js/immutable-js
+│  ├─ publisher: Lee Byron
+│  ├─ url: https://github.com/leebyron
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/immutable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/immutable/LICENSE
+├─ import-cwd@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/import-cwd
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-cwd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-cwd/license
+├─ import-fresh@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/import-fresh
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cosmiconfig/node_modules/import-fresh
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cosmiconfig/node_modules/import-fresh/license
+├─ import-fresh@3.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/import-fresh
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-fresh
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-fresh/license
+├─ import-from@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/import-from
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-from
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-from/license
+├─ import-html-entry@1.14.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kuitos/import-html-entry
+│  ├─ publisher: Kuitos
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-html-entry
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-html-entry/LICENSE
+├─ import-local@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/import-local
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-local
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-local/license
+├─ import-local@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/import-local
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli/node_modules/import-local
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli/node_modules/import-local/license
+├─ imurmurhash@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jensyt/imurmurhash-js
+│  ├─ publisher: Jens Taylor
+│  ├─ email: jensyt@gmail.com
+│  ├─ url: https://github.com/homebrewing
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/imurmurhash
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/imurmurhash/README.md
+├─ indent-string@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/indent-string
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/indent-string
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/indent-string/license
+├─ indexes-of@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dominictarr/indexes-of
+│  ├─ publisher: Dominic Tarr
+│  ├─ email: dominic.tarr@gmail.com
+│  ├─ url: dominictarr.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/indexes-of
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/indexes-of/LICENSE
+├─ indexof@0.0.1
+│  ├─ licenses: MIT*
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/indexof
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/indexof/Readme.md
+├─ infer-owner@1.0.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/infer-owner
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: https://izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/infer-owner
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/infer-owner/LICENSE
+├─ inflight@1.0.6
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/inflight
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inflight
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inflight/LICENSE
+├─ inherits@2.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/inherits
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/util/node_modules/inherits
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/util/node_modules/inherits/LICENSE
+├─ inherits@2.0.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/inherits
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser/node_modules/inherits
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser/node_modules/inherits/LICENSE
+├─ inherits@2.0.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/inherits
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inherits
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inherits/LICENSE
+├─ inquirer@6.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/SBoudrias/Inquirer.js
+│  ├─ publisher: Simon Boudrias
+│  ├─ email: admin@simonboudrias.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inquirer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inquirer/LICENSE
+├─ inquirer@7.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/SBoudrias/Inquirer.js
+│  ├─ publisher: Simon Boudrias
+│  ├─ email: admin@simonboudrias.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/inquirer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/inquirer/LICENSE
+├─ insert-text-at-cursor@0.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/grassator/insert-text-at-cursor
+│  ├─ publisher: Dmitriy Kubyshkin
+│  ├─ email: dmitriy@kubyshkin.name
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/insert-text-at-cursor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/insert-text-at-cursor/LICENSE
+├─ internal-ip@4.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/internal-ip
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/internal-ip
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/internal-ip/license
+├─ internal-slot@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/internal-slot
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/internal-slot
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/internal-slot/LICENSE
+├─ internmap@2.0.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/mbostock/internmap
+│  ├─ publisher: Mike Bostock
+│  ├─ url: https://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/internmap
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/internmap/LICENSE
+├─ interpret@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gulpjs/interpret
+│  ├─ publisher: Gulp Team
+│  ├─ email: team@gulpjs.com
+│  ├─ url: http://gulpjs.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/interpret
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/interpret/LICENSE
+├─ intersection-observer@0.12.2
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/GoogleChromeLabs/intersection-observer
+│  ├─ publisher: Philip Walton
+│  ├─ email: philip@philipwalton.com
+│  ├─ url: http://philipwalton.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/intersection-observer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/intersection-observer/README.md
+├─ invariant@2.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zertosh/invariant
+│  ├─ publisher: Andres Suarez
+│  ├─ email: zertosh@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/invariant
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/invariant/LICENSE
+├─ ip-regex@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/ip-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ip-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ip-regex/license
+├─ ip@1.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/node-ip
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ip
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ip/README.md
+├─ ip@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/node-ip
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socks/node_modules/ip
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socks/node_modules/ip/README.md
+├─ ipaddr.js@1.9.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/whitequark/ipaddr.js
+│  ├─ publisher: whitequark
+│  ├─ email: whitequark@whitequark.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ipaddr.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ipaddr.js/LICENSE
+├─ is-absolute-url@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-absolute-url
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: http://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-absolute-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-absolute-url/license
+├─ is-absolute-url@3.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-absolute-url
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/is-absolute-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/is-absolute-url/license
+├─ is-accessor-descriptor@0.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-accessor-descriptor
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property/node_modules/is-accessor-descriptor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property/node_modules/is-accessor-descriptor/LICENSE
+├─ is-accessor-descriptor@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-accessor-descriptor
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-accessor-descriptor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-accessor-descriptor/LICENSE
+├─ is-arguments@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-arguments
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-arguments
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-arguments/LICENSE
+├─ is-array-buffer@3.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-array-buffer
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-array-buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-array-buffer/LICENSE
+├─ is-arrayish@0.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/qix-/node-is-arrayish
+│  ├─ publisher: Qix
+│  ├─ url: http://github.com/qix-
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-arrayish
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-arrayish/LICENSE
+├─ is-arrayish@0.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/qix-/node-is-arrayish
+│  ├─ publisher: Qix
+│  ├─ url: http://github.com/qix-
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/simple-swizzle/node_modules/is-arrayish
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/simple-swizzle/node_modules/is-arrayish/LICENSE
+├─ is-bigint@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-bigint
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-bigint
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-bigint/LICENSE
+├─ is-binary-path@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-binary-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/is-binary-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/is-binary-path/license
+├─ is-binary-path@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-binary-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-binary-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-binary-path/license
+├─ is-boolean-object@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-boolean-object
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-boolean-object
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-boolean-object/LICENSE
+├─ is-buffer@1.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/is-buffer
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: http://feross.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-buffer/LICENSE
+├─ is-callable@1.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-callable
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-callable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-callable/LICENSE
+├─ is-ci@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/watson/is-ci
+│  ├─ publisher: Thomas Watson Steen
+│  ├─ email: w@tson.dk
+│  ├─ url: https://twitter.com/wa7son
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-ci
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-ci/LICENSE
+├─ is-color-stop@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pigcan/is-color-stop
+│  ├─ publisher: pigcan
+│  ├─ email: jiangjay818@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-color-stop
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-color-stop/LICENSE
+├─ is-core-module@2.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-core-module
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-core-module
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-core-module/LICENSE
+├─ is-data-descriptor@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-data-descriptor
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property/node_modules/is-data-descriptor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property/node_modules/is-data-descriptor/LICENSE
+├─ is-data-descriptor@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-data-descriptor
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-data-descriptor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-data-descriptor/LICENSE
+├─ is-date-object@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-date-object
+│  ├─ publisher: Jordan Harband
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-date-object
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-date-object/LICENSE
+├─ is-descriptor@0.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-descriptor
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property/node_modules/is-descriptor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property/node_modules/is-descriptor/LICENSE
+├─ is-descriptor@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-descriptor
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-descriptor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-descriptor/LICENSE
+├─ is-directory@0.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-directory
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-directory
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-directory/LICENSE
+├─ is-docker@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-docker
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-docker
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-docker/license
+├─ is-extendable@0.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-extendable
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-extendable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-extendable/LICENSE
+├─ is-extendable@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-extendable
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/split-string/node_modules/is-extendable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/split-string/node_modules/is-extendable/LICENSE
+├─ is-extglob@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-extglob
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-extglob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-extglob/LICENSE
+├─ is-fullwidth-code-point@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-fullwidth-code-point
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-fullwidth-code-point
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-fullwidth-code-point/license
+├─ is-fullwidth-code-point@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-fullwidth-code-point
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string-width/node_modules/is-fullwidth-code-point
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string-width/node_modules/is-fullwidth-code-point/license
+├─ is-glob@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-glob
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/glob-parent/node_modules/is-glob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/glob-parent/node_modules/is-glob/LICENSE
+├─ is-glob@4.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/is-glob
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-glob
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-glob/LICENSE
+├─ is-lambda@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/watson/is-lambda
+│  ├─ publisher: Thomas Watson Steen
+│  ├─ email: w@tson.dk
+│  ├─ url: https://twitter.com/wa7son
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-lambda
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-lambda/LICENSE
+├─ is-negative-zero@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-negative-zero
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-negative-zero
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-negative-zero/LICENSE
+├─ is-number-object@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-number-object
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-number-object
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-number-object/LICENSE
+├─ is-number@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-number
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-number
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-number/LICENSE
+├─ is-number@7.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-number
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-regex-range/node_modules/is-number
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-regex-range/node_modules/is-number/LICENSE
+├─ is-obj@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-obj
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-obj
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-obj/license
+├─ is-path-cwd@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-path-cwd
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-path-cwd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-path-cwd/license
+├─ is-path-in-cwd@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-path-in-cwd
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-path-in-cwd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-path-in-cwd/license
+├─ is-path-inside@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-path-inside
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-path-inside
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-path-inside/license
+├─ is-plain-obj@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-plain-obj
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sort-keys/node_modules/is-plain-obj
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sort-keys/node_modules/is-plain-obj/license
+├─ is-plain-obj@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-plain-obj
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-plain-obj
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-plain-obj/license
+├─ is-plain-object@2.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-plain-object
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-plain-object
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-plain-object/LICENSE
+├─ is-regex@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-regex
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-regex/LICENSE
+├─ is-resolvable@1.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/shinnn/is-resolvable
+│  ├─ publisher: Shinnosuke Watanabe
+│  ├─ url: https://github.com/shinnn
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-resolvable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-resolvable/LICENSE
+├─ is-shared-array-buffer@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-shared-array-buffer
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-shared-array-buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-shared-array-buffer/LICENSE
+├─ is-stream@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-stream
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-stream/license
+├─ is-stream@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-stream
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/is-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/is-stream/license
+├─ is-string@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/is-string
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-string
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-string/LICENSE
+├─ is-symbol@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-symbol
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-symbol
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-symbol/LICENSE
+├─ is-typed-array@1.1.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-typed-array
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-typed-array
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-typed-array/LICENSE
+├─ is-typedarray@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/hughsk/is-typedarray
+│  ├─ publisher: Hugh Kennedy
+│  ├─ email: hughskennedy@gmail.com
+│  ├─ url: http://hughsk.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-typedarray
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-typedarray/LICENSE.md
+├─ is-valid-hostname@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/miguelmota/is-valid-hostname
+│  ├─ publisher: Miguel Mota
+│  ├─ email: hello@miguelmota.com
+│  ├─ url: https://miguelmota.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-valid-hostname
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-valid-hostname/LICENSE
+├─ is-weakref@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-weakref
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-weakref
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-weakref/LICENSE
+├─ is-windows@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-windows
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-windows
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-windows/LICENSE
+├─ is-wsl@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-wsl
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-wsl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-wsl/license
+├─ is-wsl@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-wsl
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clipboardy/node_modules/is-wsl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/clipboardy/node_modules/is-wsl/license
+├─ isarray@0.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/isarray
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/isarray
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/isarray/README.md
+├─ isarray@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/isarray
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/isarray
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/isarray/README.md
+├─ isarray@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/isarray
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-binary2/node_modules/isarray
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-binary2/node_modules/isarray/README.md
+├─ isarray@2.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/isarray
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-array-concat/node_modules/isarray
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-array-concat/node_modules/isarray/LICENSE
+├─ isexe@2.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/isexe
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/isexe
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/isexe/LICENSE
+├─ isobject@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/isobject
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unset-value/node_modules/has-value/node_modules/isobject
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unset-value/node_modules/has-value/node_modules/isobject/LICENSE
+├─ isobject@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/isobject
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/isobject
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/isobject/LICENSE
+├─ isstream@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rvagg/isstream
+│  ├─ publisher: Rod Vagg
+│  ├─ email: rod@vagg.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/isstream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/isstream/LICENSE.md
+├─ jackspeak@2.2.1
+│  ├─ licenses: BlueOak-1.0.0
+│  ├─ repository: https://github.com/isaacs/jackspeak
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jackspeak
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jackspeak/LICENSE.md
+├─ javascript-stringify@1.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/javascript-stringify
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/javascript-stringify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/javascript-stringify/LICENSE
+├─ javascript-stringify@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/javascript-stringify
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/javascript-stringify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/javascript-stringify/LICENSE
+├─ jest-worker@26.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jest-worker
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jest-worker/LICENSE
+├─ js-message@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/RIAEvangelist/js-message
+│  ├─ publisher: Brandon Nozaki Miller
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/js-message
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/js-message/licence.md
+├─ js-tokens@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lydell/js-tokens
+│  ├─ publisher: Simon Lydell
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/js-tokens
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/js-tokens/LICENSE
+├─ js-yaml@3.14.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodeca/js-yaml
+│  ├─ publisher: Vladimir Zapparov
+│  ├─ email: dervus.grim@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gray-matter/node_modules/js-yaml
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/gray-matter/node_modules/js-yaml/LICENSE
+├─ js-yaml@4.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodeca/js-yaml
+│  ├─ publisher: Vladimir Zapparov
+│  ├─ email: dervus.grim@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/js-yaml
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/js-yaml/LICENSE
+├─ jsbn@0.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/andyperlitch/jsbn
+│  ├─ publisher: Tom Wu
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsbn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsbn/LICENSE
+├─ jsesc@0.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/jsesc
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: http://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regjsparser/node_modules/jsesc
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regjsparser/node_modules/jsesc/LICENSE-MIT.txt
+├─ jsesc@2.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/jsesc
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsesc
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsesc/LICENSE-MIT.txt
+├─ jshint@2.13.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshint/jshint
+│  ├─ publisher: Anton Kovalyov
+│  ├─ email: anton@kovalyov.net
+│  ├─ url: http://anton.kovalyov.net/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jshint
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jshint/LICENSE
+├─ json-parse-better-errors@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zkat/json-parse-better-errors
+│  ├─ publisher: Kat Marchán
+│  ├─ email: kzm@zkat.tech
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-parse-better-errors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-parse-better-errors/LICENSE.md
+├─ json-parse-even-better-errors@2.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/npm/json-parse-even-better-errors
+│  ├─ publisher: Kat Marchán
+│  ├─ email: kzm@zkat.tech
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-parse-even-better-errors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-parse-even-better-errors/LICENSE.md
+├─ json-schema-traverse@0.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/epoberezkin/json-schema-traverse
+│  ├─ publisher: Evgeny Poberezkin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-schema-traverse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-schema-traverse/LICENSE
+├─ json-schema@0.4.0
+│  ├─ licenses: (AFL-2.1 OR BSD-3-Clause)
+│  ├─ repository: https://github.com/kriszyp/json-schema
+│  ├─ publisher: Kris Zyp
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-schema
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-schema/LICENSE
+├─ json-stable-stringify-without-jsonify@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/samn/json-stable-stringify
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-stable-stringify-without-jsonify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-stable-stringify-without-jsonify/LICENSE
+├─ json-stringify-safe@5.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/json-stringify-safe
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-stringify-safe
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json-stringify-safe/LICENSE
+├─ json5@0.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/aseemk/json5
+│  ├─ publisher: Aseem Kishore
+│  ├─ email: aseem.kishore@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin/node_modules/json5
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin/node_modules/json5/LICENSE.md
+├─ json5@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/json5/json5
+│  ├─ publisher: Aseem Kishore
+│  ├─ email: aseem.kishore@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-utils/node_modules/json5
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-utils/node_modules/json5/LICENSE.md
+├─ json5@2.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/json5/json5
+│  ├─ publisher: Aseem Kishore
+│  ├─ email: aseem.kishore@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json5
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/json5/LICENSE.md
+├─ jsonfile@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jprichardson/node-jsonfile
+│  ├─ publisher: JP Richardson
+│  ├─ email: jprichardson@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsonfile
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsonfile/LICENSE
+├─ jsonlint@1.6.3
+│  ├─ licenses: MIT*
+│  ├─ repository: https://github.com/zaach/jsonlint
+│  ├─ publisher: Zach Carter
+│  ├─ email: zach@carter.name
+│  ├─ url: http://zaa.ch
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsonlint
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsonlint/README.md
+├─ jsprim@1.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/joyent/node-jsprim
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsprim
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jsprim/LICENSE
+├─ jwt-decode@3.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/auth0/jwt-decode
+│  ├─ publisher: Jose F. Romaniello
+│  ├─ email: jfromaniello@gmail.com
+│  ├─ url: http://joseoncode.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jwt-decode
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jwt-decode/LICENSE
+├─ katex@0.13.24
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/KaTeX/KaTeX
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/katex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/katex/LICENSE
+├─ khroma@1.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fabiospampinato/khroma
+│  ├─ publisher: Fabio Spampinato
+│  ├─ email: spampinabio@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/khroma
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/khroma/LICENSE
+├─ killable@1.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/marten-de-vries/killable
+│  ├─ publisher: Marten de Vries
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/killable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/killable/LICENSE
+├─ kind-of@3.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/kind-of
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-number/node_modules/kind-of
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/is-number/node_modules/kind-of/LICENSE
+├─ kind-of@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/kind-of
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-values/node_modules/kind-of
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/has-values/node_modules/kind-of/LICENSE
+├─ kind-of@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/kind-of
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property/node_modules/is-descriptor/node_modules/kind-of
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/define-property/node_modules/is-descriptor/node_modules/kind-of/LICENSE
+├─ kind-of@6.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/kind-of
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/kind-of
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/kind-of/LICENSE
+├─ klona@2.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/klona
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke.edwards05@gmail.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/klona
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/klona/license
+├─ last-call-webpack-plugin@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/NMFR/last-call-webpack-plugin
+│  ├─ publisher: Nuno Rodrigues
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/last-call-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/last-call-webpack-plugin/LICENSE
+├─ launch-editor-middleware@2.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/yyx990803/launch-editor
+│  ├─ publisher: Evan You
+│  └─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/launch-editor-middleware
+├─ launch-editor@2.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/yyx990803/launch-editor
+│  ├─ publisher: Evan You
+│  └─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/launch-editor
+├─ levn@0.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gkz/levn
+│  ├─ publisher: George Zahariev
+│  ├─ email: z@georgezahariev.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/levn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/levn/LICENSE
+├─ lilconfig@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/antonk52/lilconfig
+│  ├─ publisher: antonk52
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lilconfig
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lilconfig/LICENSE
+├─ lines-and-columns@1.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eventualbuddha/lines-and-columns
+│  ├─ publisher: Brian Donovan
+│  ├─ email: brian@donovans.cc
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lines-and-columns
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lines-and-columns/LICENSE
+├─ linkify-it@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/linkify-it
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/linkify-it
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/linkify-it/LICENSE
+├─ linkify-it@3.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/linkify-it
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/linkify-it
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/linkify-it/LICENSE
+├─ linkify-it@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/linkify-it
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/linkify-it
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/linkify-it/LICENSE
+├─ loader-fs-cache@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/viankakrisna/loader-fs-cache
+│  ├─ publisher: Ade Viankakrisna Fadlil
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache/LICENSE
+├─ loader-runner@2.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/loader-runner
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-runner
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-runner/LICENSE
+├─ loader-utils@0.2.17
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/loader-utils
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin/node_modules/loader-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/html-webpack-plugin/node_modules/loader-utils/LICENSE
+├─ loader-utils@1.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/loader-utils
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-utils/LICENSE
+├─ loader-utils@2.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/loader-utils
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/raw-loader/node_modules/loader-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/raw-loader/node_modules/loader-utils/LICENSE
+├─ loadjs@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/muicss/loadjs
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loadjs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loadjs/LICENSE.txt
+├─ locate-path@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/locate-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-up/node_modules/locate-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-up/node_modules/locate-path/license
+├─ locate-path@5.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/locate-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/locate-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/locate-path/license
+├─ lodash.debounce@4.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.debounce
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.debounce/LICENSE
+├─ lodash.defaultsdeep@4.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.defaultsdeep
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.defaultsdeep/LICENSE
+├─ lodash.kebabcase@4.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.kebabcase
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.kebabcase/LICENSE
+├─ lodash.mapvalues@4.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.mapvalues
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.mapvalues/LICENSE
+├─ lodash.memoize@4.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.memoize
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.memoize/LICENSE
+├─ lodash.transform@4.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.transform
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.transform/LICENSE
+├─ lodash.uniq@4.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.uniq
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash.uniq/LICENSE
+├─ lodash@4.17.21
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lodash/LICENSE
+├─ log-symbols@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/log-symbols
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/log-symbols
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/log-symbols/license
+├─ loglevel@1.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pimterry/loglevel
+│  ├─ publisher: Tim Perry
+│  ├─ email: pimterry@gmail.com
+│  ├─ url: http://tim-perry.co.uk
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loglevel
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loglevel/LICENSE-MIT
+├─ loose-envify@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zertosh/loose-envify
+│  ├─ publisher: Andres Suarez
+│  ├─ email: zertosh@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loose-envify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loose-envify/LICENSE
+├─ lottie-web-vue@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/garbit/lottie-web-vue
+│  ├─ publisher: Andy Garbett
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lottie-web-vue
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lottie-web-vue/LICENSE
+├─ lottie-web@5.12.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/airbnb/lottie-web
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lottie-web
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lottie-web/LICENSE.md
+├─ lower-case@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/lower-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lower-case
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lower-case/LICENSE
+├─ lru-cache@4.1.5
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-lru-cache
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils/node_modules/lru-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils/node_modules/lru-cache/LICENSE
+├─ lru-cache@5.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-lru-cache
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lru-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lru-cache/LICENSE
+├─ lru-cache@6.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-lru-cache
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/fs/node_modules/lru-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/fs/node_modules/lru-cache/LICENSE
+├─ lru-cache@7.18.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-lru-cache
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/lru-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/lru-cache/LICENSE
+├─ lru-cache@9.1.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-lru-cache
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-scurry/node_modules/lru-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-scurry/node_modules/lru-cache/LICENSE
+├─ make-dir@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/make-dir
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/make-dir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/make-dir/license
+├─ make-dir@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/make-dir
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-dir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-dir/license
+├─ make-error@1.3.6
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/JsCommunity/make-error
+│  ├─ publisher: Julien Fontanet
+│  ├─ email: julien.fontanet@isonoe.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-error
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-error/LICENSE
+├─ make-fetch-happen@11.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/make-fetch-happen
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/LICENSE
+├─ mamacro@0.0.3
+│  ├─ licenses: MIT
+│  ├─ publisher: Sven Sauleau
+│  └─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mamacro
+├─ map-cache@0.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/map-cache
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/map-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/map-cache/LICENSE
+├─ map-visit@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/map-visit
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/map-visit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/map-visit/LICENSE
+├─ markdown-it-anchor@5.3.0
+│  ├─ licenses: Unlicense
+│  ├─ repository: https://github.com/valeriangalliat/markdown-it-anchor
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/markdown-it-anchor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/markdown-it-anchor/README.md
+├─ markdown-it-attrs@4.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/arve0/markdown-it-attrs
+│  ├─ publisher: Arve Seljebu
+│  ├─ email: arve.seljebu@gmail.com
+│  ├─ url: https://arve0.github.io
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/markdown-it-attrs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/markdown-it-attrs/LICENSE
+├─ markdown-it-chain@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ULIVZ/markdown-it-chain
+│  ├─ publisher: ULIVZ
+│  ├─ email: chl814@foxmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/markdown-it-chain
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/markdown-it-chain/LICENSE
+├─ markdown-it-container@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/markdown-it-container
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it-container
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it-container/LICENSE
+├─ markdown-it-emoji@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/markdown-it-emoji
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it-emoji
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it-emoji/LICENSE
+├─ markdown-it-table-of-contents@0.4.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Oktavilla/markdown-it-table-of-contents
+│  ├─ publisher: Oktavilla
+│  ├─ email: https://github.com/Oktavilla
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it-table-of-contents
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it-table-of-contents/LICENSE
+├─ markdown-it-task-lists@2.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/revin/markdown-it-task-lists
+│  ├─ publisher: Revin Guillen
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it-task-lists
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it-task-lists/LICENSE
+├─ markdown-it@12.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/markdown-it
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/markdown-it
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@kangc/v-md-editor/node_modules/markdown-it/LICENSE
+├─ markdown-it@13.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/markdown-it
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/markdown-it/LICENSE
+├─ markdown-it@8.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/markdown-it
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/markdown-it
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vuepress/markdown/node_modules/markdown-it/LICENSE
+├─ marked@4.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markedjs/marked
+│  ├─ publisher: Christopher Jeffrey
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/marked
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/marked/LICENSE.md
+├─ md5-es@1.8.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/logotype/es-crypto
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/md5-es
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/md5-es/README.md
+├─ md5.js@1.3.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/md5.js
+│  ├─ publisher: Kirill Fomichev
+│  ├─ email: fanatid@ya.ru
+│  ├─ url: https://github.com/fanatid
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/md5.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/md5.js/LICENSE
+├─ mdn-data@2.0.14
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/mdn/data
+│  ├─ publisher: Mozilla Developer Network
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-tree/node_modules/mdn-data
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/css-tree/node_modules/mdn-data/LICENSE
+├─ mdn-data@2.0.4
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/mdn/data
+│  ├─ publisher: Mozilla Developer Network
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mdn-data
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mdn-data/LICENSE
+├─ mdurl@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/mdurl
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mdurl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mdurl/LICENSE
+├─ media-typer@0.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/media-typer
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/media-typer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/media-typer/LICENSE
+├─ memory-fs@0.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/memory-fs
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/memory-fs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/memory-fs/README.md
+├─ memory-fs@0.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/memory-fs
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/enhanced-resolve/node_modules/memory-fs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/enhanced-resolve/node_modules/memory-fs/LICENSE
+├─ merge-descriptors@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/component/merge-descriptors
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/merge-descriptors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/merge-descriptors/LICENSE
+├─ merge-source-map@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/keik/merge-source-map
+│  ├─ publisher: keik
+│  ├─ email: k4t0.kei@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/merge-source-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/merge-source-map/LICENSE
+├─ merge-stream@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/grncdr/merge-stream
+│  ├─ publisher: Stephen Sugden
+│  ├─ email: me@stephensugden.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/merge-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/merge-stream/LICENSE
+├─ merge2@1.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/teambition/merge2
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/merge2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/merge2/LICENSE
+├─ mermaid@8.14.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/knsv/mermaid
+│  ├─ publisher: Knut Sveidqvist
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mermaid
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mermaid/LICENSE
+├─ methods@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/methods
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/methods
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/methods/LICENSE
+├─ micromatch@3.1.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/micromatch
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch/LICENSE
+├─ micromatch@4.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/micromatch
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-proxy-middleware/node_modules/micromatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/http-proxy-middleware/node_modules/micromatch/LICENSE
+├─ miller-rabin@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/miller-rabin
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/miller-rabin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/miller-rabin/README.md
+├─ mime-db@1.52.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/mime-db
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mime-db
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mime-db/LICENSE
+├─ mime-types@2.1.35
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/mime-types
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mime-types
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mime-types/LICENSE
+├─ mime@1.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/broofa/node-mime
+│  ├─ publisher: Robert Kieffer
+│  ├─ email: robert@broofa.com
+│  ├─ url: http://github.com/broofa
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/send/node_modules/mime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/send/node_modules/mime/LICENSE
+├─ mime@2.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/broofa/mime
+│  ├─ publisher: Robert Kieffer
+│  ├─ email: robert@broofa.com
+│  ├─ url: http://github.com/broofa
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/mime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/mime/LICENSE
+├─ mime@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/broofa/mime
+│  ├─ publisher: Robert Kieffer
+│  ├─ email: robert@broofa.com
+│  ├─ url: http://github.com/broofa
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mime/LICENSE
+├─ mimic-fn@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/mimic-fn
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mimic-fn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mimic-fn/license
+├─ mimic-fn@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/mimic-fn
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/onetime/node_modules/mimic-fn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/onetime/node_modules/mimic-fn/license
+├─ min-document@2.19.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/min-document
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/min-document
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/min-document/LICENCE
+├─ mini-css-extract-plugin@0.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/mini-css-extract-plugin
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/mini-css-extract-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/mini-css-extract-plugin/LICENSE
+├─ minimalistic-assert@1.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/calvinmetcalf/minimalistic-assert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minimalistic-assert
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minimalistic-assert/LICENSE
+├─ minimalistic-crypto-utils@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/minimalistic-crypto-utils
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minimalistic-crypto-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minimalistic-crypto-utils/README.md
+├─ minimatch@3.0.8
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minimatch
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jshint/node_modules/minimatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jshint/node_modules/minimatch/LICENSE
+├─ minimatch@3.1.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minimatch
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minimatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minimatch/LICENSE
+├─ minimatch@9.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minimatch
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/minimatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/minimatch/LICENSE
+├─ minimist@1.2.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/minimistjs/minimist
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minimist
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minimist/LICENSE
+├─ minipass-collect@1.0.2
+│  ├─ licenses: ISC
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: https://izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-collect
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-collect/LICENSE
+├─ minipass-fetch@3.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/npm/minipass-fetch
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-fetch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-fetch/LICENSE
+├─ minipass-flush@1.0.5
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minipass-flush
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: https://izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-flush
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-flush/LICENSE
+├─ minipass-pipeline@1.2.4
+│  ├─ licenses: ISC
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: https://izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-pipeline
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-pipeline/LICENSE
+├─ minipass-sized@1.0.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minipass-sized
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: https://izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-sized
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-sized/LICENSE
+├─ minipass@3.3.6
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minipass
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass/LICENSE
+├─ minipass@5.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minipass
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-fetch/node_modules/minipass
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minipass-fetch/node_modules/minipass/LICENSE
+├─ minipass@6.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minipass
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-scurry/node_modules/minipass
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-scurry/node_modules/minipass/LICENSE
+├─ minizlib@2.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/isaacs/minizlib
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minizlib
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/minizlib/LICENSE
+├─ mississippi@3.0.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/maxogden/mississippi
+│  ├─ publisher: max ogden
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mississippi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mississippi/license
+├─ mixin-deep@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/mixin-deep
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mixin-deep
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mixin-deep/LICENSE
+├─ mkdirp@0.5.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/node-mkdirp
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mkdirp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mkdirp/LICENSE
+├─ mkdirp@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/isaacs/node-mkdirp
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/move-file/node_modules/mkdirp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/move-file/node_modules/mkdirp/LICENSE
+├─ moment-mini@2.29.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ksloan/moment-mini
+│  ├─ publisher: Tim Wood, Iskren Chernev, Moment.js contributors
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/moment-mini
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/moment-mini/README.md
+├─ move-concurrently@1.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/move-concurrently
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/move-concurrently
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/move-concurrently/LICENSE
+├─ mrmime@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/mrmime
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke.edwards05@gmail.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mrmime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mrmime/license
+├─ ms@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zeit/ms
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon/node_modules/ms
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon/node_modules/ms/license.md
+├─ ms@2.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zeit/ms
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/debug/node_modules/ms
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/debug/node_modules/ms/license.md
+├─ ms@2.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vercel/ms
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ms
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ms/license.md
+├─ multicast-dns-service-types@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/multicast-dns-service-types
+│  ├─ publisher: Mathias Buus
+│  ├─ url: @mafintosh
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/multicast-dns-service-types
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/multicast-dns-service-types/LICENSE
+├─ multicast-dns@6.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/multicast-dns
+│  ├─ publisher: Mathias Buus
+│  ├─ url: @mafintosh
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/multicast-dns
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/multicast-dns/LICENSE
+├─ mute-stream@0.0.7
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/mute-stream
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mute-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mute-stream/LICENSE
+├─ mute-stream@0.0.8
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/mute-stream
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/mute-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/mute-stream/LICENSE
+├─ mz@2.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/normalize/mz
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mz
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/mz/LICENSE
+├─ nan@2.17.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/nan
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nan
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nan/LICENSE.md
+├─ nanoid@3.3.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ai/nanoid
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss/node_modules/nanoid
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss/node_modules/nanoid/LICENSE
+├─ nanoid@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ai/nanoid
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nanoid
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nanoid/LICENSE
+├─ nanomatch@1.2.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/nanomatch
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nanomatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nanomatch/LICENSE
+├─ natural-compare@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/litejs/natural-compare-lite
+│  ├─ publisher: Lauri Rooden
+│  ├─ url: https://github.com/litejs/natural-compare-lite
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/natural-compare
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/natural-compare/README.md
+├─ negotiator@0.6.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/negotiator
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/negotiator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/negotiator/LICENSE
+├─ neo-async@2.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/suguru03/neo-async
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/neo-async
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/neo-async/LICENSE
+├─ nice-try@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/electerious/nice-try
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nice-try
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nice-try/LICENSE
+├─ no-case@2.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/no-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/no-case
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/no-case/LICENSE
+├─ node-fetch@2.6.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bitinn/node-fetch
+│  ├─ publisher: David Frank
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-fetch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-fetch/LICENSE.md
+├─ node-forge@0.10.0
+│  ├─ licenses: (BSD-3-Clause OR GPL-2.0)
+│  ├─ repository: https://github.com/digitalbazaar/forge
+│  ├─ publisher: Digital Bazaar, Inc.
+│  ├─ email: support@digitalbazaar.com
+│  ├─ url: http://digitalbazaar.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-forge
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-forge/LICENSE
+├─ node-gyp@9.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/node-gyp
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://tootallnate.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-gyp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-gyp/LICENSE
+├─ node-libs-browser@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/node-libs-browser
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser/LICENSE
+├─ node-releases@2.0.12
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chicoxyzzy/node-releases
+│  ├─ publisher: Sergey Rubanov
+│  ├─ email: chi187@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-releases
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-releases/LICENSE
+├─ nomnom@1.8.1
+│  ├─ licenses: MIT*
+│  ├─ repository: https://github.com/harthur/nomnom
+│  ├─ publisher: Heather Arthur
+│  ├─ email: fayearthur@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nomnom
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nomnom/LICENSE
+├─ nopt@6.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/nopt
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nopt
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nopt/LICENSE
+├─ normalize-package-data@2.5.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/npm/normalize-package-data
+│  ├─ publisher: Meryn Stol
+│  ├─ email: merynstol@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/normalize-package-data
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/normalize-package-data/LICENSE
+├─ normalize-path@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/normalize-path
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie/node_modules/normalize-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie/node_modules/normalize-path/README.md
+├─ normalize-path@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/normalize-path
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/anymatch/node_modules/normalize-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/anymatch/node_modules/normalize-path/LICENSE
+├─ normalize-path@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/normalize-path
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/normalize-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/normalize-path/LICENSE
+├─ normalize-range@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jamestalmage/normalize-range
+│  ├─ publisher: James Talmage
+│  ├─ email: james@talmage.io
+│  ├─ url: github.com/jamestalmage
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/normalize-range
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/normalize-range/license
+├─ normalize-url@1.9.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/normalize-url
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/normalize-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/normalize-url/license
+├─ normalize-url@3.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/normalize-url
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/normalize-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/normalize-url/license
+├─ normalize-url@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/normalize-url
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/normalize-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/normalize-url/license
+├─ npm-run-path@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/npm-run-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/npm-run-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/npm-run-path/license
+├─ npm-run-path@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/npm-run-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/npm-run-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/npm-run-path/license
+├─ npmlog@6.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/npmlog
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/npmlog
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/npmlog/LICENSE.md
+├─ nth-check@1.0.2
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/nth-check
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo/node_modules/nth-check
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo/node_modules/nth-check/LICENSE
+├─ nth-check@2.1.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/nth-check
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nth-check
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nth-check/LICENSE
+├─ num2fraction@1.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/yisibl/num2fraction
+│  ├─ publisher: yisi
+│  ├─ email: yiorsi@gmail.com
+│  ├─ url: http://iyunlu.com/view
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/num2fraction
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/num2fraction/LICENSE
+├─ oauth-sign@0.9.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mikeal/oauth-sign
+│  ├─ publisher: Mikeal Rogers
+│  ├─ email: mikeal.rogers@gmail.com
+│  ├─ url: http://www.futurealoof.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/oauth-sign
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/oauth-sign/LICENSE
+├─ object-assign@4.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/object-assign
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-assign
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-assign/license
+├─ object-copy@0.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/object-copy
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-copy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-copy/LICENSE
+├─ object-hash@1.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/puleos/object-hash
+│  ├─ publisher: Scott Puleo
+│  ├─ email: puleos@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-hash
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-hash/LICENSE
+├─ object-inspect@1.12.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/object-inspect
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-inspect
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-inspect/LICENSE
+├─ object-is@1.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/object-is
+│  ├─ publisher: Jordan Harband
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-is
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-is/LICENSE
+├─ object-keys@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/object-keys
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-keys
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-keys/LICENSE
+├─ object-visit@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/object-visit
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-visit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object-visit/LICENSE
+├─ object.assign@4.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/object.assign
+│  ├─ publisher: Jordan Harband
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.assign
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.assign/LICENSE
+├─ object.getownpropertydescriptors@2.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/object.getownpropertydescriptors
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.getownpropertydescriptors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.getownpropertydescriptors/LICENSE
+├─ object.omit@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/object.omit
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.omit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.omit/LICENSE
+├─ object.pick@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/object.pick
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.pick
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.pick/LICENSE
+├─ object.values@1.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Object.values
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/object.values/LICENSE
+├─ obuf@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/offset-buffer
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/obuf
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/obuf/LICENSE
+├─ on-finished@2.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/on-finished
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/on-finished
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/on-finished/LICENSE
+├─ on-headers@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/on-headers
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/on-headers
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/on-headers/LICENSE
+├─ once@1.4.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/once
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/once
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/once/LICENSE
+├─ onetime@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/onetime
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/restore-cursor/node_modules/onetime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/restore-cursor/node_modules/onetime/license
+├─ onetime@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/onetime
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/onetime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/onetime/license
+├─ open@6.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/open
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/open
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/open/license
+├─ opencollective-postinstall@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/opencollective/opencollective-postinstall
+│  ├─ publisher: Xavier Damman
+│  ├─ url: @xdamman
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/opencollective-postinstall
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/opencollective-postinstall/LICENSE
+├─ opener@1.5.2
+│  ├─ licenses: (WTFPL OR MIT)
+│  ├─ repository: https://github.com/domenic/opener
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/opener
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/opener/LICENSE.txt
+├─ opn@5.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/opn
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/opn
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/opn/license
+├─ optimize-css-assets-webpack-plugin@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/NMFR/optimize-css-assets-webpack-plugin
+│  ├─ publisher: Nuno Rodrigues
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/LICENSE
+├─ optionator@0.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gkz/optionator
+│  ├─ publisher: George Zahariev
+│  ├─ email: z@georgezahariev.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optionator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optionator/LICENSE
+├─ ora@3.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/ora
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ora
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ora/license
+├─ orderedmap@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/marijnh/orderedmap
+│  ├─ publisher: Marijn Haverbeke
+│  ├─ email: marijn@haverbeke.berlin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/orderedmap
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/orderedmap/LICENSE
+├─ os-browserify@0.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/CoderPuppy/os-browserify
+│  ├─ publisher: CoderPuppy
+│  ├─ email: coderpup@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/os-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/os-browserify/LICENSE
+├─ os-tmpdir@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/os-tmpdir
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/os-tmpdir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/os-tmpdir/license
+├─ p-finally@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-finally
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-finally
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-finally/license
+├─ p-finally@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-finally
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/p-finally
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/default-gateway/node_modules/p-finally/license
+├─ p-limit@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-limit
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-limit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-limit/license
+├─ p-limit@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-limit
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser-webpack-plugin/node_modules/p-limit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser-webpack-plugin/node_modules/p-limit/license
+├─ p-locate@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-locate
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-up/node_modules/p-locate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-up/node_modules/p-locate/license
+├─ p-locate@4.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-locate
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-locate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-locate/license
+├─ p-map@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-map
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/del/node_modules/p-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/del/node_modules/p-map/license
+├─ p-map@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-map
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-map/license
+├─ p-retry@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-retry
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-retry
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-retry/license
+├─ p-try@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-try
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-try
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/p-try/license
+├─ pako@1.0.11
+│  ├─ licenses: (MIT AND Zlib)
+│  ├─ repository: https://github.com/nodeca/pako
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pako
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pako/LICENSE
+├─ parallel-transform@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/parallel-transform
+│  ├─ publisher: Mathias Buus Madsen
+│  ├─ email: mathiasbuus@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parallel-transform
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parallel-transform/LICENSE
+├─ param-case@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/param-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/param-case
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/param-case/LICENSE
+├─ parent-module@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/parent-module
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parent-module
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parent-module/license
+├─ parse-asn1@5.1.6
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/crypto-browserify/parse-asn1
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parse-asn1
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parse-asn1/LICENSE
+├─ parse-json@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/parse-json
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cosmiconfig/node_modules/parse-json
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cosmiconfig/node_modules/parse-json/license
+├─ parse-json@5.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/parse-json
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parse-json
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parse-json/license
+├─ parse5-htmlparser2-tree-adapter@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inikulin/parse5
+│  ├─ publisher: Ivan Nikulin
+│  ├─ email: ifaaan@gmail.com
+│  ├─ url: https://github.com/inikulin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parse5-htmlparser2-tree-adapter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parse5-htmlparser2-tree-adapter/LICENSE
+├─ parse5@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inikulin/parse5
+│  ├─ publisher: Ivan Nikulin
+│  ├─ email: ifaaan@gmail.com
+│  ├─ url: https://github.com/inikulin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-highlight/node_modules/parse5
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cli-highlight/node_modules/parse5/LICENSE
+├─ parse5@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inikulin/parse5
+│  ├─ publisher: Ivan Nikulin
+│  ├─ email: ifaaan@gmail.com
+│  ├─ url: https://github.com/inikulin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parse5
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parse5/LICENSE
+├─ parseqs@0.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/get/querystring
+│  ├─ publisher: Gal Koren
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parseqs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parseqs/LICENSE
+├─ parserlib@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/CSSLint/parser-lib
+│  ├─ publisher: Nicholas C. Zakas
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parserlib
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parserlib/LICENSE
+├─ parseuri@0.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/get/parseuri
+│  ├─ publisher: Gal Koren
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parseuri
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parseuri/LICENSE
+├─ parseurl@1.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pillarjs/parseurl
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parseurl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/parseurl/LICENSE
+├─ pascalcase@0.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/pascalcase
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pascalcase
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pascalcase/LICENSE
+├─ path-browserify@0.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/path-browserify
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-browserify/LICENSE
+├─ path-dirname@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es128/path-dirname
+│  ├─ publisher: Elan Shanker
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-dirname
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-dirname/license
+├─ path-exists@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-exists
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache/node_modules/path-exists
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache/node_modules/path-exists/license
+├─ path-exists@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-exists
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-up/node_modules/path-exists
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/find-up/node_modules/path-exists/license
+├─ path-exists@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-exists
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-exists
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-exists/license
+├─ path-is-absolute@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-is-absolute
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-is-absolute
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-is-absolute/license
+├─ path-is-inside@1.0.2
+│  ├─ licenses: (WTFPL OR MIT)
+│  ├─ repository: https://github.com/domenic/path-is-inside
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-is-inside
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-is-inside/LICENSE.txt
+├─ path-key@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-key
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-key
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-key/license
+├─ path-key@3.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-key
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn/node_modules/path-key
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn/node_modules/path-key/license
+├─ path-parse@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jbgutierrez/path-parse
+│  ├─ publisher: Javier Blanco
+│  ├─ email: http://jbgutierrez.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-parse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-parse/LICENSE
+├─ path-scurry@1.9.2
+│  ├─ licenses: BlueOak-1.0.0
+│  ├─ repository: https://github.com/isaacs/path-walker
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: https://blog.izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-scurry
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-scurry/LICENSE.md
+├─ path-to-regexp@0.1.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/component/path-to-regexp
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-to-regexp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-to-regexp/LICENSE
+├─ path-type@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-type
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-type
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-type/license
+├─ pbkdf2@3.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/pbkdf2
+│  ├─ publisher: Daniel Cousens
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pbkdf2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pbkdf2/LICENSE
+├─ pdfjs-dist@2.6.347
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mozilla/pdfjs-dist
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pdfjs-dist
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pdfjs-dist/LICENSE
+├─ perfect-scrollbar@1.5.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mdbootstrap/perfect-scrollbar
+│  ├─ publisher: Hyunje Jun
+│  ├─ email: me@noraesae.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/perfect-scrollbar
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/perfect-scrollbar/LICENSE
+├─ performance-now@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/braveg1rl/performance-now
+│  ├─ publisher: Braveg1rl
+│  ├─ email: braveg1rl@outlook.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/performance-now
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/performance-now/license.txt
+├─ picocolors@0.2.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/alexeyraspopov/picocolors
+│  ├─ publisher: Alexey Raspopov
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils/node_modules/picocolors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils/node_modules/picocolors/LICENSE
+├─ picocolors@1.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/alexeyraspopov/picocolors
+│  ├─ publisher: Alexey Raspopov
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/picocolors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/picocolors/LICENSE
+├─ picomatch@2.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/picomatch
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/picomatch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/picomatch/LICENSE
+├─ pify@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pify
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/del/node_modules/globby/node_modules/pify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/del/node_modules/globby/node_modules/pify/license
+├─ pify@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pify
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-type/node_modules/pify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/path-type/node_modules/pify/license
+├─ pify@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pify
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pify/license
+├─ pinkie-promise@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/floatdrop/pinkie-promise
+│  ├─ publisher: Vsevolod Strukchinsky
+│  ├─ email: floatdrop@gmail.com
+│  ├─ url: github.com/floatdrop
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pinkie-promise
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pinkie-promise/license
+├─ pinkie@2.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/floatdrop/pinkie
+│  ├─ publisher: Vsevolod Strukchinsky
+│  ├─ email: floatdrop@gmail.com
+│  ├─ url: github.com/floatdrop
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pinkie
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pinkie/license
+├─ pkg-dir@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pkg-dir
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache/node_modules/pkg-dir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/loader-fs-cache/node_modules/pkg-dir/license
+├─ pkg-dir@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pkg-dir
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/pkg-dir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/pkg-dir/license
+├─ pkg-dir@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pkg-dir
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pkg-dir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pkg-dir/license
+├─ plyr@3.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sampotts/plyr
+│  ├─ publisher: Sam Potts
+│  ├─ email: sam@potts.es
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/plyr
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/plyr/LICENSE.md
+├─ pnp-webpack-plugin@1.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/arcanis/pnp-webpack-plugin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pnp-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pnp-webpack-plugin/README.md
+├─ popper.js@1.16.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/FezVrasta/popper.js
+│  ├─ publisher: Federico Zivolo
+│  ├─ email: federico.zivolo@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/popper.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/popper.js/README.md
+├─ portfinder@1.0.32
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/http-party/node-portfinder
+│  ├─ publisher: Charlie Robbins
+│  ├─ email: charlie.robbins@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/portfinder
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/portfinder/LICENSE
+├─ posix-character-classes@0.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/posix-character-classes
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/posix-character-classes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/posix-character-classes/LICENSE
+├─ postcss-calc@7.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-calc
+│  ├─ publisher: Andy Jansson
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-calc
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-calc/LICENSE
+├─ postcss-calc@8.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-calc
+│  ├─ publisher: Andy Jansson
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-calc
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-calc/LICENSE
+├─ postcss-colormin@4.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-colormin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-colormin/LICENSE-MIT
+├─ postcss-colormin@5.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-colormin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-colormin/LICENSE-MIT
+├─ postcss-convert-values@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-convert-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-convert-values/LICENSE-MIT
+├─ postcss-convert-values@5.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-convert-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-convert-values/LICENSE-MIT
+├─ postcss-discard-comments@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-discard-comments
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-discard-comments/LICENSE-MIT
+├─ postcss-discard-comments@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-discard-comments
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-discard-comments/LICENSE-MIT
+├─ postcss-discard-duplicates@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-discard-duplicates
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-discard-duplicates/LICENSE-MIT
+├─ postcss-discard-duplicates@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-discard-duplicates
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-discard-duplicates/LICENSE-MIT
+├─ postcss-discard-empty@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-discard-empty
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-discard-empty/LICENSE-MIT
+├─ postcss-discard-empty@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-discard-empty
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-discard-empty/LICENSE-MIT
+├─ postcss-discard-overridden@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Justineo
+│  ├─ email: justice360@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-discard-overridden
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-discard-overridden/LICENSE
+├─ postcss-discard-overridden@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Justineo
+│  ├─ email: justice360@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-discard-overridden
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-discard-overridden/LICENSE
+├─ postcss-load-config@2.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-load-config
+│  ├─ publisher: Michael Ciniawky
+│  ├─ email: michael.ciniawsky@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-load-config
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-load-config/LICENSE
+├─ postcss-loader@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-loader
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-loader/LICENSE
+├─ postcss-merge-longhand@4.0.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-merge-longhand
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-merge-longhand/LICENSE-MIT
+├─ postcss-merge-longhand@5.1.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-merge-longhand
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-merge-longhand/LICENSE-MIT
+├─ postcss-merge-rules@4.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-merge-rules
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-merge-rules/LICENSE-MIT
+├─ postcss-merge-rules@5.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-merge-rules
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-merge-rules/LICENSE-MIT
+├─ postcss-minify-font-values@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-minify-font-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-minify-font-values/LICENSE
+├─ postcss-minify-font-values@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-minify-font-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-minify-font-values/LICENSE
+├─ postcss-minify-gradients@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-minify-gradients
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-minify-gradients/LICENSE-MIT
+├─ postcss-minify-gradients@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-minify-gradients
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-minify-gradients/LICENSE-MIT
+├─ postcss-minify-params@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-minify-params
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-minify-params/LICENSE
+├─ postcss-minify-params@5.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-minify-params
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-minify-params/LICENSE
+├─ postcss-minify-selectors@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-minify-selectors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-minify-selectors/LICENSE-MIT
+├─ postcss-minify-selectors@5.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-minify-selectors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-minify-selectors/LICENSE-MIT
+├─ postcss-modules-extract-imports@2.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/css-modules/postcss-modules-extract-imports
+│  ├─ publisher: Glen Maddern
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-modules-extract-imports
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-modules-extract-imports/LICENSE
+├─ postcss-modules-local-by-default@3.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/css-modules/postcss-modules-local-by-default
+│  ├─ publisher: Mark Dalgleish
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-modules-local-by-default
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-modules-local-by-default/LICENSE
+├─ postcss-modules-scope@2.2.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/css-modules/postcss-modules-scope
+│  ├─ publisher: Glen Maddern
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-modules-scope
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-modules-scope/LICENSE
+├─ postcss-modules-values@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/css-modules/postcss-modules-values
+│  ├─ publisher: Glen Maddern
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-modules-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-modules-values/LICENSE
+├─ postcss-normalize-charset@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-charset
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-charset/LICENSE
+├─ postcss-normalize-charset@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-charset
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-charset/LICENSE
+├─ postcss-normalize-display-values@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-display-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-display-values/LICENSE-MIT
+├─ postcss-normalize-display-values@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-display-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-display-values/LICENSE-MIT
+├─ postcss-normalize-positions@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-positions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-positions/LICENSE-MIT
+├─ postcss-normalize-positions@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-positions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-positions/LICENSE-MIT
+├─ postcss-normalize-repeat-style@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-repeat-style
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-repeat-style/LICENSE-MIT
+├─ postcss-normalize-repeat-style@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-repeat-style
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-repeat-style/LICENSE-MIT
+├─ postcss-normalize-string@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-string
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-string/LICENSE-MIT
+├─ postcss-normalize-string@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-string
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-string/LICENSE-MIT
+├─ postcss-normalize-timing-functions@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-timing-functions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-timing-functions/LICENSE-MIT
+├─ postcss-normalize-timing-functions@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-timing-functions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-timing-functions/LICENSE-MIT
+├─ postcss-normalize-unicode@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-unicode
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-unicode/LICENSE-MIT
+├─ postcss-normalize-unicode@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-unicode
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-unicode/LICENSE-MIT
+├─ postcss-normalize-url@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-url/LICENSE-MIT
+├─ postcss-normalize-url@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-url/LICENSE-MIT
+├─ postcss-normalize-whitespace@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-whitespace
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-normalize-whitespace/LICENSE-MIT
+├─ postcss-normalize-whitespace@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-whitespace
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-normalize-whitespace/LICENSE-MIT
+├─ postcss-ordered-values@4.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-ordered-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-ordered-values/LICENSE-MIT
+├─ postcss-ordered-values@5.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-ordered-values
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-ordered-values/LICENSE-MIT
+├─ postcss-reduce-initial@4.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-reduce-initial
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-reduce-initial/LICENSE-MIT
+├─ postcss-reduce-initial@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-reduce-initial
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-reduce-initial/LICENSE-MIT
+├─ postcss-reduce-transforms@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-reduce-transforms
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-reduce-transforms/LICENSE-MIT
+├─ postcss-reduce-transforms@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-reduce-transforms
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-reduce-transforms/LICENSE-MIT
+├─ postcss-selector-parser@3.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-selector-parser
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stylehacks/node_modules/postcss-selector-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stylehacks/node_modules/postcss-selector-parser/LICENSE-MIT
+├─ postcss-selector-parser@6.0.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-selector-parser
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-selector-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-selector-parser/LICENSE-MIT
+├─ postcss-svgo@4.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-svgo
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-svgo/LICENSE-MIT
+├─ postcss-svgo@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-svgo
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-svgo/LICENSE-MIT
+├─ postcss-unique-selectors@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-unique-selectors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-unique-selectors/LICENSE-MIT
+├─ postcss-unique-selectors@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-unique-selectors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-unique-selectors/LICENSE-MIT
+├─ postcss-value-parser@3.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TrySound/postcss-value-parser
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-colormin/node_modules/postcss-value-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-colormin/node_modules/postcss-value-parser/LICENSE
+├─ postcss-value-parser@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TrySound/postcss-value-parser
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-value-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-value-parser/LICENSE
+├─ postcss@7.0.39
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils/node_modules/postcss
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils/node_modules/postcss/LICENSE
+├─ postcss@8.4.24
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss/LICENSE
+├─ prelude-ls@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gkz/prelude-ls
+│  ├─ publisher: George Zahariev
+│  ├─ email: z@georgezahariev.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prelude-ls
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prelude-ls/LICENSE
+├─ prepend-http@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/prepend-http
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prepend-http
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prepend-http/license
+├─ prettier@2.8.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prettier/prettier
+│  ├─ publisher: James Long
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prettier
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prettier/LICENSE
+├─ pretty-error@2.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/AriaMinaei/pretty-error
+│  ├─ publisher: Aria Minaei
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pretty-error
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pretty-error/LICENSE
+├─ prismjs@1.29.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/PrismJS/prism
+│  ├─ publisher: Lea Verou
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prismjs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prismjs/LICENSE
+├─ process-nextick-args@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/calvinmetcalf/process-nextick-args
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/process-nextick-args
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/process-nextick-args/license.md
+├─ process@0.11.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/shtylman/node-process
+│  ├─ publisher: Roman Shtylman
+│  ├─ email: shtylman@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/process
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/process/LICENSE
+├─ progress@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/node-progress
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/progress
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/progress/LICENSE
+├─ promise-inflight@1.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/iarna/promise-inflight
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/promise-inflight
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/promise-inflight/LICENSE
+├─ promise-retry@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/IndigoUnited/node-promise-retry
+│  ├─ publisher: IndigoUnited
+│  ├─ email: hello@indigounited.com
+│  ├─ url: http://indigounited.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/promise-retry
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/promise-retry/LICENSE
+├─ prosemirror-changeset@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-changeset
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-changeset
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-changeset/LICENSE
+├─ prosemirror-collab@1.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-collab
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-collab
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-collab/LICENSE
+├─ prosemirror-commands@1.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-commands
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-commands
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-commands/LICENSE
+├─ prosemirror-dropcursor@1.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-dropcursor
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-dropcursor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-dropcursor/LICENSE
+├─ prosemirror-gapcursor@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-gapcursor
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-gapcursor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-gapcursor/LICENSE
+├─ prosemirror-history@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-history
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-history
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-history/LICENSE
+├─ prosemirror-inputrules@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-inputrules
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-inputrules
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-inputrules/LICENSE
+├─ prosemirror-keymap@1.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-keymap
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-keymap
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-keymap/LICENSE
+├─ prosemirror-markdown@1.11.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-markdown
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-markdown
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-markdown/LICENSE
+├─ prosemirror-menu@1.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-menu
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-menu
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-menu/LICENSE
+├─ prosemirror-model@1.19.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-model
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-model
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-model/LICENSE
+├─ prosemirror-schema-basic@1.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-schema-basic
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-schema-basic
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-schema-basic/LICENSE
+├─ prosemirror-schema-list@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-schema-list
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-schema-list
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-schema-list/LICENSE
+├─ prosemirror-state@1.4.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-state
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-state
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-state/LICENSE
+├─ prosemirror-tables@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-tables
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-tables
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-tables/LICENSE
+├─ prosemirror-trailing-node@2.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/remirror/remirror
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-trailing-node
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-trailing-node/LICENSE
+├─ prosemirror-transform@1.7.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-transform
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-transform
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-transform/LICENSE
+├─ prosemirror-view@1.31.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prosemirror/prosemirror-view
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-view
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prosemirror-view/LICENSE
+├─ proxy-addr@2.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/proxy-addr
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/proxy-addr
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/proxy-addr/LICENSE
+├─ proxy-from-env@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Rob--W/proxy-from-env
+│  ├─ publisher: Rob Wu
+│  ├─ email: rob@robwu.nl
+│  ├─ url: https://robwu.nl/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/proxy-from-env
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/proxy-from-env/LICENSE
+├─ prr@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rvagg/prr
+│  ├─ publisher: Rod Vagg
+│  ├─ email: rod@vagg.org
+│  ├─ url: https://github.com/rvagg
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prr
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/prr/LICENSE.md
+├─ pseudomap@1.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/pseudomap
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pseudomap
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pseudomap/LICENSE
+├─ psl@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lupomontero/psl
+│  ├─ publisher: Lupo Montero
+│  ├─ email: lupomontero@gmail.com
+│  ├─ url: https://lupomontero.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/psl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/psl/LICENSE
+├─ public-encrypt@4.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/publicEncrypt
+│  ├─ publisher: Calvin Metcalf
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/public-encrypt
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/public-encrypt/LICENSE
+├─ pump@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/pump
+│  ├─ publisher: Mathias Buus Madsen
+│  ├─ email: mathiasbuus@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pumpify/node_modules/pump
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pumpify/node_modules/pump/LICENSE
+├─ pump@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/pump
+│  ├─ publisher: Mathias Buus Madsen
+│  ├─ email: mathiasbuus@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pump
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pump/LICENSE
+├─ pumpify@1.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/pumpify
+│  ├─ publisher: Mathias Buus
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pumpify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/pumpify/LICENSE
+├─ punycode@1.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bestiejs/punycode.js
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser/node_modules/punycode
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser/node_modules/punycode/LICENSE-MIT.txt
+├─ punycode@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/punycode.js
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/punycode
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/punycode/LICENSE-MIT.txt
+├─ q@1.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kriskowal/q
+│  ├─ publisher: Kris Kowal
+│  ├─ email: kris@cixar.com
+│  ├─ url: https://github.com/kriskowal
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/q
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/q/LICENSE
+├─ qiankun@2.10.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kuitos/qiankun
+│  ├─ publisher: Kuitos
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/qiankun
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/qiankun/LICENSE
+├─ qs@6.11.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/ljharb/qs
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/body-parser/node_modules/qs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/body-parser/node_modules/qs/LICENSE.md
+├─ qs@6.11.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/ljharb/qs
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/qs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/qs/LICENSE.md
+├─ qs@6.5.3
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/ljharb/qs
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/request/node_modules/qs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/request/node_modules/qs/LICENSE.md
+├─ query-string@4.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/query-string
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/query-string
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/query-string/license
+├─ querystring-es3@0.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mike-spainhower/querystring
+│  ├─ publisher: Irakli Gozalishvili
+│  ├─ email: rfobic@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/querystring-es3
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/querystring-es3/License.md
+├─ querystringify@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/unshiftio/querystringify
+│  ├─ publisher: Arnout Kazemier
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/querystringify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/querystringify/LICENSE
+├─ randombytes@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/randombytes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/randombytes
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/randombytes/LICENSE
+├─ randomfill@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/randomfill
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/randomfill
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/randomfill/LICENSE
+├─ range-parser@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/range-parser
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ url: http://tjholowaychuk.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/range-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/range-parser/LICENSE
+├─ rangetouch@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sampotts/rangetouch
+│  ├─ publisher: Sam Potts
+│  ├─ email: sam@potts.es
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rangetouch
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rangetouch/license.md
+├─ raw-body@2.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stream-utils/raw-body
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/raw-body
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/raw-body/LICENSE
+├─ raw-loader@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/raw-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/raw-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/raw-loader/LICENSE
+├─ read-pkg@5.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/read-pkg
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/read-pkg
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/read-pkg/license
+├─ readable-stream@1.1.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/isaacs/readable-stream
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/readable-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/readable-stream/LICENSE
+├─ readable-stream@2.3.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/readable-stream
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/readable-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/readable-stream/LICENSE
+├─ readable-stream@3.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/readable-stream
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hash-base/node_modules/readable-stream
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/hash-base/node_modules/readable-stream/LICENSE
+├─ readdirp@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/paulmillr/readdirp
+│  ├─ publisher: Thorsten Lorenz
+│  ├─ email: thlorenz@gmx.de
+│  ├─ url: thlorenz.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/readdirp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2/node_modules/readdirp/LICENSE
+├─ readdirp@3.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/paulmillr/readdirp
+│  ├─ publisher: Thorsten Lorenz
+│  ├─ email: thlorenz@gmx.de
+│  ├─ url: thlorenz.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/readdirp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/readdirp/LICENSE
+├─ rechoir@0.7.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gulpjs/rechoir
+│  ├─ publisher: Gulp Team
+│  ├─ email: team@gulpjs.com
+│  ├─ url: http://gulpjs.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rechoir
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rechoir/LICENSE
+├─ regenerate-unicode-properties@10.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/regenerate-unicode-properties
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regenerate-unicode-properties
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regenerate-unicode-properties/LICENSE-MIT.txt
+├─ regenerate@1.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/regenerate
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regenerate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regenerate/LICENSE-MIT.txt
+├─ regenerator-runtime@0.13.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/regenerator/tree/main/packages/runtime
+│  ├─ publisher: Ben Newman
+│  ├─ email: bn@cs.stanford.edu
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regenerator-runtime
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regenerator-runtime/LICENSE
+├─ regenerator-transform@0.15.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/regenerator/tree/main/packages/transform
+│  ├─ publisher: Ben Newman
+│  ├─ email: bn@cs.stanford.edu
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regenerator-transform
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regenerator-transform/LICENSE
+├─ regex-not@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/regex-not
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regex-not
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regex-not/LICENSE
+├─ regexp.prototype.flags@1.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/RegExp.prototype.flags
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regexp.prototype.flags
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regexp.prototype.flags/LICENSE
+├─ regexpp@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mysticatea/regexpp
+│  ├─ publisher: Toru Nagashima
+│  ├─ url: https://github.com/mysticatea
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regexpp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regexpp/LICENSE
+├─ regexpu-core@5.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/regexpu-core
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regexpu-core
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regexpu-core/LICENSE-MIT.txt
+├─ regjsparser@0.9.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/jviereck/regjsparser
+│  ├─ publisher: 'Julian Viereck'
+│  ├─ email: julian.viereck@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regjsparser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/regjsparser/LICENSE.BSD
+├─ relateurl@0.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stevenvachon/relateurl
+│  ├─ publisher: Steven Vachon
+│  ├─ email: contact@svachon.com
+│  ├─ url: http://www.svachon.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/relateurl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/relateurl/license
+├─ remove-trailing-separator@1.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/darsain/remove-trailing-separator
+│  ├─ publisher: darsain
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/remove-trailing-separator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/remove-trailing-separator/license
+├─ renderkid@2.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/AriaMinaei/RenderKid
+│  ├─ publisher: Aria Minaei
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/renderkid
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/renderkid/LICENSE
+├─ repeat-element@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/repeat-element
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/repeat-element
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/repeat-element/LICENSE
+├─ repeat-string@1.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/repeat-string
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: http://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/repeat-string
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/repeat-string/LICENSE
+├─ request@2.88.2
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/request/request
+│  ├─ publisher: Mikeal Rogers
+│  ├─ email: mikeal.rogers@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/request
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/request/LICENSE
+├─ require-directory@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/troygoode/node-require-directory
+│  ├─ publisher: Troy Goode
+│  ├─ email: troygoode@gmail.com
+│  ├─ url: http://github.com/troygoode/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/require-directory
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/require-directory/LICENSE
+├─ require-main-filename@2.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/require-main-filename
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/require-main-filename
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/require-main-filename/LICENSE.txt
+├─ requires-port@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/unshiftio/requires-port
+│  ├─ publisher: Arnout Kazemier
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/requires-port
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/requires-port/LICENSE
+├─ resize-observer-polyfill@1.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/que-etc/resize-observer-polyfill
+│  ├─ publisher: Denis Rul
+│  ├─ email: que.etc@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resize-observer-polyfill
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resize-observer-polyfill/LICENSE
+├─ resolve-cwd@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/resolve-cwd
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resolve-cwd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resolve-cwd/license
+├─ resolve-cwd@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/resolve-cwd
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli/node_modules/resolve-cwd
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli/node_modules/resolve-cwd/license
+├─ resolve-from@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/resolve-from
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resolve-from
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resolve-from/license
+├─ resolve-from@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/resolve-from
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-fresh/node_modules/resolve-from
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/import-fresh/node_modules/resolve-from/license
+├─ resolve-from@5.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/resolve-from
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli/node_modules/resolve-from
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli/node_modules/resolve-from/license
+├─ resolve-url@0.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lydell/resolve-url
+│  ├─ publisher: Simon Lydell
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resolve-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resolve-url/LICENSE
+├─ resolve@1.22.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/browserify/resolve
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resolve
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/resolve/LICENSE
+├─ restore-cursor@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/restore-cursor
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/restore-cursor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/restore-cursor/license
+├─ restore-cursor@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/restore-cursor
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/restore-cursor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/restore-cursor/license
+├─ ret@0.1.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fent/ret.js
+│  ├─ publisher: Roly Fentanes
+│  ├─ url: https://github.com/fent
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ret
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ret/LICENSE
+├─ retry@0.12.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tim-kos/node-retry
+│  ├─ publisher: Tim Koschützki
+│  ├─ email: tim@debuggable.com
+│  ├─ url: http://debuggable.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/retry
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/retry/License
+├─ rgb-regex@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/regexps/rgb-regex
+│  ├─ publisher: John Otander
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rgb-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rgb-regex/LICENSE.md
+├─ rgba-regex@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/johnotander/rgba-regex
+│  ├─ publisher: John Otander
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rgba-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rgba-regex/LICENSE.md
+├─ rimraf@2.6.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/rimraf
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/flat-cache/node_modules/rimraf
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/flat-cache/node_modules/rimraf/LICENSE
+├─ rimraf@2.7.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/rimraf
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rimraf
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rimraf/LICENSE
+├─ rimraf@3.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/rimraf
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/move-file/node_modules/rimraf
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/move-file/node_modules/rimraf/LICENSE
+├─ ripemd160@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/ripemd160
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ripemd160
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ripemd160/LICENSE
+├─ robust-predicates@3.0.2
+│  ├─ licenses: Unlicense
+│  ├─ repository: https://github.com/mourner/robust-predicates
+│  ├─ publisher: Vladimir Agafonkin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/robust-predicates
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/robust-predicates/LICENSE
+├─ rope-sequence@1.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/marijnh/rope-sequence
+│  ├─ publisher: Marijn Haverbeke
+│  ├─ email: marijn@haverbeke.berlin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rope-sequence
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rope-sequence/LICENSE
+├─ rss-parser@3.13.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bobby-brennan/rss-parser
+│  ├─ publisher: Bobby Brennan
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rss-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rss-parser/LICENSE
+├─ run-async@2.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/SBoudrias/run-async
+│  ├─ publisher: Simon Boudrias
+│  ├─ email: admin@simonboudrias.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/run-async
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/run-async/LICENSE
+├─ run-queue@1.0.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/iarna/run-queue
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/run-queue
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/run-queue/README.md
+├─ rw@1.3.3
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/mbostock/rw
+│  ├─ publisher: Mike Bostock
+│  ├─ url: http://bost.ocks.org/mike
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rw
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rw/LICENSE
+├─ rxjs@6.6.7
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/reactivex/rxjs
+│  ├─ publisher: Ben Lesh
+│  ├─ email: ben@benlesh.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rxjs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/rxjs/LICENSE.txt
+├─ safe-array-concat@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/safe-array-concat
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-array-concat
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-array-concat/LICENSE
+├─ safe-buffer@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/safe-buffer
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: http://feross.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/readable-stream/node_modules/safe-buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/readable-stream/node_modules/safe-buffer/LICENSE
+├─ safe-buffer@5.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/safe-buffer
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: https://feross.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-buffer/LICENSE
+├─ safe-regex-test@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/safe-regex-test
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-regex-test
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-regex-test/LICENSE
+├─ safe-regex@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/safe-regex
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safe-regex/LICENSE
+├─ safer-buffer@2.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ChALkeR/safer-buffer
+│  ├─ publisher: Nikita Skovoroda
+│  ├─ email: chalkerx@gmail.com
+│  ├─ url: https://github.com/ChALkeR
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safer-buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/safer-buffer/LICENSE
+├─ sass-loader@10.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/sass-loader
+│  ├─ publisher: J. Tangelder
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sass-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sass-loader/LICENSE
+├─ sass@1.63.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sass/dart-sass
+│  ├─ publisher: Natalie Weizenbaum
+│  ├─ email: nweiz@google.com
+│  ├─ url: https://github.com/nex3
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sass
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sass/LICENSE
+├─ sax@1.2.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/sax-js
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sax
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sax/LICENSE
+├─ schema-utils@0.4.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/schema-utils
+│  ├─ publisher: webpack Contrib
+│  ├─ url: https://github.com/webpack-contrib
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/worker-loader/node_modules/schema-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/worker-loader/node_modules/schema-utils/LICENSE
+├─ schema-utils@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/schema-utils
+│  ├─ publisher: webpack Contrib
+│  ├─ url: https://github.com/webpack-contrib
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-loader/node_modules/schema-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/postcss-loader/node_modules/schema-utils/LICENSE
+├─ schema-utils@2.7.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/schema-utils
+│  ├─ publisher: webpack Contrib
+│  ├─ url: https://github.com/webpack-contrib
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/schema-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/schema-utils/LICENSE
+├─ schema-utils@3.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/schema-utils
+│  ├─ publisher: webpack Contrib
+│  ├─ url: https://github.com/webpack-contrib
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/raw-loader/node_modules/schema-utils
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/raw-loader/node_modules/schema-utils/LICENSE
+├─ screenfull@5.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/screenfull.js
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/screenfull
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/screenfull/license
+├─ scrollmonitor@1.2.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stutrek/scrollMonitor
+│  ├─ publisher: Stu Kabakoff
+│  ├─ email: stukabakoff@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/scrollmonitor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/scrollmonitor/LICENSE
+├─ section-matter@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/section-matter
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/section-matter
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/section-matter/LICENSE
+├─ select-hose@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/select-hose
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/select-hose
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/select-hose/README.md
+├─ selfsigned@1.10.14
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jfromaniello/selfsigned
+│  ├─ publisher: José F. Romaniello
+│  ├─ email: jfromaniello@gmail.com
+│  ├─ url: http://joseoncode.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/selfsigned
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/selfsigned/LICENSE
+├─ semver@5.7.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/node-semver
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/execa/node_modules/semver
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/execa/node_modules/semver/LICENSE
+├─ semver@6.3.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/node-semver
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/semver
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/semver/LICENSE
+├─ semver@7.5.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/node-semver
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/fs/node_modules/semver
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@npmcli/fs/node_modules/semver/LICENSE
+├─ send@0.18.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pillarjs/send
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/send
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/send/LICENSE
+├─ serialize-javascript@4.0.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/yahoo/serialize-javascript
+│  ├─ publisher: Eric Ferraiuolo
+│  ├─ email: edf@ericf.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serialize-javascript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serialize-javascript/LICENSE
+├─ serialize-javascript@5.0.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/yahoo/serialize-javascript
+│  ├─ publisher: Eric Ferraiuolo
+│  ├─ email: edf@ericf.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser-webpack-plugin/node_modules/serialize-javascript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser-webpack-plugin/node_modules/serialize-javascript/LICENSE
+├─ serve-index@1.9.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/serve-index
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index/LICENSE
+├─ serve-static@1.15.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/serve-static
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-static
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-static/LICENSE
+├─ set-blocking@2.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/set-blocking
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/set-blocking
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/set-blocking/LICENSE.txt
+├─ set-value@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/set-value
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/set-value
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/set-value/LICENSE
+├─ setimmediate@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/YuzuJS/setImmediate
+│  ├─ publisher: YuzuJS
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/setimmediate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/setimmediate/LICENSE.txt
+├─ setprototypeof@1.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/wesleytodd/setprototypeof
+│  ├─ publisher: Wes Todd
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index/node_modules/setprototypeof
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index/node_modules/setprototypeof/LICENSE
+├─ setprototypeof@1.2.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/wesleytodd/setprototypeof
+│  ├─ publisher: Wes Todd
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/setprototypeof
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/setprototypeof/LICENSE
+├─ sha.js@2.4.11
+│  ├─ licenses: (MIT AND BSD-3-Clause)
+│  ├─ repository: https://github.com/crypto-browserify/sha.js
+│  ├─ publisher: Dominic Tarr
+│  ├─ email: dominic.tarr@gmail.com
+│  ├─ url: dominictarr.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sha.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sha.js/LICENSE
+├─ shallow-clone@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/shallow-clone
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/shallow-clone
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/shallow-clone/LICENSE
+├─ shebang-command@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kevva/shebang-command
+│  ├─ publisher: Kevin Martensson
+│  ├─ email: kevinmartensson@gmail.com
+│  ├─ url: github.com/kevva
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/shebang-command
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/shebang-command/license
+├─ shebang-command@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kevva/shebang-command
+│  ├─ publisher: Kevin Mårtensson
+│  ├─ email: kevinmartensson@gmail.com
+│  ├─ url: github.com/kevva
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn/node_modules/shebang-command
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn/node_modules/shebang-command/license
+├─ shebang-regex@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/shebang-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/shebang-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/shebang-regex/license
+├─ shebang-regex@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/shebang-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn/node_modules/shebang-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn/node_modules/shebang-regex/license
+├─ shell-quote@1.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/shell-quote
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/shell-quote
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/shell-quote/LICENSE
+├─ side-channel@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/side-channel
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/side-channel
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/side-channel/LICENSE
+├─ signal-exit@3.0.7
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/tapjs/signal-exit
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/signal-exit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/signal-exit/LICENSE.txt
+├─ signal-exit@4.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/tapjs/signal-exit
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/foreground-child/node_modules/signal-exit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/foreground-child/node_modules/signal-exit/LICENSE.txt
+├─ simple-swizzle@0.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/qix-/node-simple-swizzle
+│  ├─ publisher: Qix
+│  ├─ url: http://github.com/qix-
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/simple-swizzle
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/simple-swizzle/LICENSE
+├─ simple-uploader.js@0.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/simple-uploader/Uploader
+│  ├─ publisher: dolymood
+│  ├─ email: dolymood@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/simple-uploader.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/simple-uploader.js/LICENSE
+├─ single-spa@5.9.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/single-spa/single-spa
+│  ├─ publisher: Joel Denning
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/single-spa
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/single-spa/LICENSE
+├─ sirv@1.0.19
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/sirv
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke@lukeed.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sirv
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sirv/readme.md
+├─ slash@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/slash
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: http://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/slash
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/slash/readme.md
+├─ slash@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/slash
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/slash
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/slash/license
+├─ slice-ansi@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/slice-ansi
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/slice-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/slice-ansi/license
+├─ smart-buffer@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/JoshGlazebrook/smart-buffer
+│  ├─ publisher: Josh Glazebrook
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/smart-buffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/smart-buffer/LICENSE
+├─ snapdragon-node@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/snapdragon-node
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon-node
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon-node/LICENSE
+├─ snapdragon-util@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/snapdragon-util
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon-util
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon-util/LICENSE
+├─ snapdragon@0.8.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/snapdragon
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon/LICENSE
+├─ socket.io-client@2.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Automattic/socket.io-client
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socket.io-client
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socket.io-client/LICENSE
+├─ socket.io-parser@3.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Automattic/socket.io-parser
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socket.io-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socket.io-parser/LICENSE
+├─ sockjs-client@1.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sockjs/sockjs-client
+│  ├─ publisher: Bryce Kahle
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sockjs-client
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sockjs-client/LICENSE
+├─ sockjs@0.3.24
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sockjs/sockjs-node
+│  ├─ publisher: Marek Majkowski
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sockjs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sockjs/LICENSE
+├─ socks-proxy-agent@7.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/node-socks-proxy-agent
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socks-proxy-agent
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socks-proxy-agent/README.md
+├─ socks@2.7.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/JoshGlazebrook/socks
+│  ├─ publisher: Josh Glazebrook
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socks
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/socks/LICENSE
+├─ sort-keys@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/sort-keys
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sort-keys
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sort-keys/license
+├─ sortablejs@1.10.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/SortableJS/Sortable
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sortablejs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sortablejs/LICENSE
+├─ source-list-map@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/source-list-map
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-list-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-list-map/LICENSE
+├─ source-map-js@1.0.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/7rulnik/source-map-js
+│  ├─ publisher: Valentin 7rulnik Semirulnik
+│  ├─ email: v7rulnik@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map-js/LICENSE
+├─ source-map-resolve@0.5.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lydell/source-map-resolve
+│  ├─ publisher: Simon Lydell
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map-resolve
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map-resolve/LICENSE
+├─ source-map-support@0.5.21
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/evanw/node-source-map-support
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map-support
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map-support/LICENSE.md
+├─ source-map-url@0.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lydell/source-map-url
+│  ├─ publisher: Simon Lydell
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map-url/LICENSE
+├─ source-map@0.5.7
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/mozilla/source-map
+│  ├─ publisher: Nick Fitzgerald
+│  ├─ email: nfitzgerald@mozilla.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon/node_modules/source-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/snapdragon/node_modules/source-map/LICENSE
+├─ source-map@0.6.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/mozilla/source-map
+│  ├─ publisher: Nick Fitzgerald
+│  ├─ email: nfitzgerald@mozilla.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/source-map/LICENSE
+├─ source-map@0.7.4
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/mozilla/source-map
+│  ├─ publisher: Nick Fitzgerald
+│  ├─ email: nfitzgerald@mozilla.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/webpack-sources/node_modules/source-map
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@types/webpack-sources/node_modules/source-map/LICENSE
+├─ spdx-correct@3.2.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/jslicense/spdx-correct.js
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdx-correct
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdx-correct/LICENSE
+├─ spdx-exceptions@2.3.0
+│  ├─ licenses: CC-BY-3.0
+│  ├─ repository: https://github.com/kemitchell/spdx-exceptions.json
+│  ├─ publisher: The Linux Foundation
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdx-exceptions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdx-exceptions/README.md
+├─ spdx-expression-parse@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jslicense/spdx-expression-parse.js
+│  ├─ publisher: Kyle E. Mitchell
+│  ├─ email: kyle@kemitchell.com
+│  ├─ url: https://kemitchell.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdx-expression-parse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdx-expression-parse/LICENSE
+├─ spdx-license-ids@3.0.13
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/jslicense/spdx-license-ids
+│  ├─ publisher: Shinnosuke Watanabe
+│  ├─ url: https://github.com/shinnn
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdx-license-ids
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdx-license-ids/README.md
+├─ spdy-transport@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/spdy-http2/spdy-transport
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdy-transport
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdy-transport/README.md
+├─ spdy@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/node-spdy
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor.indutny@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/spdy/README.md
+├─ split-string@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/split-string
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/split-string
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/split-string/LICENSE
+├─ sprintf-js@1.0.3
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/alexei/sprintf.js
+│  ├─ publisher: Alexandru Marasteanu
+│  ├─ email: hello@alexei.ro
+│  ├─ url: http://alexei.ro/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sprintf-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sprintf-js/LICENSE
+├─ sshpk@1.17.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/joyent/node-sshpk
+│  ├─ publisher: Joyent, Inc
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sshpk
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sshpk/LICENSE
+├─ ssr-window@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nolimits4web/ssr-window
+│  ├─ publisher: Vladimir Kharlampidi
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ssr-window
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ssr-window/LICENSE
+├─ ssri@10.0.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/ssri
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ssri
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ssri/LICENSE.md
+├─ ssri@6.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/zkat/ssri
+│  ├─ publisher: Kat Marchán
+│  ├─ email: kzm@sykosomatic.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cacache/node_modules/ssri
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cacache/node_modules/ssri/LICENSE.md
+├─ ssri@8.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/ssri
+│  ├─ publisher: Kat Marchán
+│  ├─ email: kzm@sykosomatic.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression-webpack-plugin/node_modules/ssri
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/compression-webpack-plugin/node_modules/ssri/LICENSE.md
+├─ stable@0.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Two-Screen/stable
+│  ├─ publisher: Angry Bytes
+│  ├─ email: info@angrybytes.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stable/README.md
+├─ stackframe@1.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stacktracejs/stackframe
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stackframe
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stackframe/LICENSE
+├─ static-extend@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/static-extend
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/static-extend
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/static-extend/LICENSE
+├─ statuses@1.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/statuses
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index/node_modules/statuses
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/serve-index/node_modules/statuses/LICENSE
+├─ statuses@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/statuses
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/statuses
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/statuses/LICENSE
+├─ stream-browserify@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/browserify/stream-browserify
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stream-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stream-browserify/LICENSE
+├─ stream-each@1.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/stream-each
+│  ├─ publisher: Mathias Buus
+│  ├─ url: @mafintosh
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stream-each
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stream-each/LICENSE
+├─ stream-http@2.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jhiesey/stream-http
+│  ├─ publisher: John Hiesey
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stream-http
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stream-http/LICENSE
+├─ stream-shift@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/stream-shift
+│  ├─ publisher: Mathias Buus
+│  ├─ url: @mafintosh
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stream-shift
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stream-shift/LICENSE
+├─ strict-uri-encode@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kevva/strict-uri-encode
+│  ├─ publisher: Kevin Mårtensson
+│  ├─ email: kevinmartensson@gmail.com
+│  ├─ url: github.com/kevva
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strict-uri-encode
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strict-uri-encode/license
+├─ string-width@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/string-width
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inquirer/node_modules/string-width
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inquirer/node_modules/string-width/license
+├─ string-width@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/string-width
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/table/node_modules/string-width
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/table/node_modules/string-width/license
+├─ string-width@4.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/string-width
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string-width
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string-width/license
+├─ string-width@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/string-width
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/string-width
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/string-width/license
+├─ string.prototype.trim@1.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/String.prototype.trim
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string.prototype.trim
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string.prototype.trim/LICENSE
+├─ string.prototype.trimend@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/String.prototype.trimEnd
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string.prototype.trimend
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string.prototype.trimend/LICENSE
+├─ string.prototype.trimstart@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/String.prototype.trimStart
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string.prototype.trimstart
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string.prototype.trimstart/LICENSE
+├─ string_decoder@0.10.31
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rvagg/string_decoder
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/string_decoder
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlparser2/node_modules/string_decoder/LICENSE
+├─ string_decoder@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/string_decoder
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/readable-stream/node_modules/string_decoder
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/readable-stream/node_modules/string_decoder/LICENSE
+├─ string_decoder@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/string_decoder
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string_decoder
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/string_decoder/LICENSE
+├─ strip-ansi@0.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: http://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nomnom/node_modules/strip-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/nomnom/node_modules/strip-ansi/readme.md
+├─ strip-ansi@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/strip-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/renderkid/node_modules/strip-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/renderkid/node_modules/strip-ansi/license
+├─ strip-ansi@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/strip-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inquirer/node_modules/string-width/node_modules/strip-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/inquirer/node_modules/string-width/node_modules/strip-ansi/license
+├─ strip-ansi@5.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/strip-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ora/node_modules/strip-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ora/node_modules/strip-ansi/license
+├─ strip-ansi@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/strip-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-ansi/license
+├─ strip-ansi@7.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/strip-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/strip-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/strip-ansi/license
+├─ strip-bom-string@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/strip-bom-string
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-bom-string
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-bom-string/LICENSE
+├─ strip-eof@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-eof
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-eof
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-eof/license
+├─ strip-final-newline@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-final-newline
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-final-newline
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-final-newline/license
+├─ strip-indent@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-indent
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-indent
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-indent/license
+├─ strip-json-comments@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-json-comments
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jshint/node_modules/strip-json-comments
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/jshint/node_modules/strip-json-comments/license
+├─ strip-json-comments@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-json-comments
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/strip-json-comments
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/strip-json-comments/license
+├─ strip-json-comments@3.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-json-comments
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-json-comments
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/strip-json-comments/license
+├─ style-resources-loader@1.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/yenshih/style-resources-loader
+│  ├─ publisher: Yan Shi
+│  ├─ email: yenshih95@gmail.com
+│  ├─ url: https://github.com/yenshih
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/style-resources-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/style-resources-loader/LICENSE
+├─ stylehacks@4.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stylehacks
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stylehacks/LICENSE-MIT
+├─ stylehacks@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/stylehacks
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/stylehacks/LICENSE-MIT
+├─ stylis@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thysultan/stylis.js
+│  ├─ publisher: Sultan Tarimo
+│  ├─ email: sultantarimo@me.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stylis
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/stylis/LICENSE
+├─ supports-color@5.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/supports-color
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chalk/node_modules/supports-color
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/chalk/node_modules/supports-color/license
+├─ supports-color@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/supports-color
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/supports-color
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/supports-color/license
+├─ supports-color@7.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/supports-color
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/supports-color
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/htmlhint/node_modules/supports-color/license
+├─ supports-preserve-symlinks-flag@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/node-supports-preserve-symlinks-flag
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/supports-preserve-symlinks-flag
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/supports-preserve-symlinks-flag/LICENSE
+├─ svg-tags@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/element-io/svg-tags
+│  ├─ publisher: Athan Reines
+│  ├─ email: kgryte@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg-tags
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg-tags/LICENSE
+├─ svg.draggable.js@2.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/svgdotjs/svg.draggable.js
+│  ├─ publisher: Wout Fierens
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.draggable.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.draggable.js/LICENSE
+├─ svg.easing.js@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/wout/svg.easing.js
+│  ├─ publisher: Wout Fierens
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.easing.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.easing.js/LICENSE
+├─ svg.filter.js@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/wout/svg.filter.js
+│  ├─ publisher: Wout Fierens
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.filter.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.filter.js/LICENSE
+├─ svg.js@2.7.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/svgdotjs/svg.js
+│  ├─ publisher: Wout Fierens
+│  ├─ email: wout@mick-wout.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.js/LICENSE.txt
+├─ svg.pathmorphing.js@0.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/svgdotjs/svg.pathmorphing.js
+│  ├─ publisher: Ulrich-Matthias Schäfer
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.pathmorphing.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.pathmorphing.js/LICENSE
+├─ svg.resize.js@1.4.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/svgdotjs/svg.resize.js
+│  ├─ publisher: Ulrich-Matthias Schäfer
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.resize.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.resize.js/LICENSE
+├─ svg.select.js@2.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/svgdotjs/svg.select.js
+│  ├─ publisher: Ulrich-Matthias Schäfer
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.select.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svg.select.js/LICENSE
+├─ svg.select.js@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/svgdotjs/svg.select.js
+│  ├─ publisher: Ulrich-Matthias Schäfer
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/apexcharts/node_modules/svg.select.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/apexcharts/node_modules/svg.select.js/LICENSE
+├─ svgo@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/svg/svgo
+│  ├─ publisher: Kir Belevich
+│  ├─ email: kir@belevi.ch
+│  ├─ url: https://github.com/deepsweet
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/svgo/LICENSE
+├─ svgo@2.8.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/svg/svgo
+│  ├─ publisher: Kir Belevich
+│  ├─ email: kir@belevi.ch
+│  ├─ url: https://github.com/deepsweet
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/svgo
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/optimize-css-assets-webpack-plugin/node_modules/svgo/LICENSE
+├─ swiper@5.4.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nolimits4web/Swiper
+│  ├─ publisher: Vladimir Kharlampidi
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/swiper
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/swiper/LICENSE
+├─ table@5.4.6
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/gajus/table
+│  ├─ publisher: Gajus Kuizinas
+│  ├─ email: gajus@gajus.com
+│  ├─ url: http://gajus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/table
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/table/LICENSE
+├─ tapable@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/tapable
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tapable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tapable/LICENSE
+├─ tar@6.1.15
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-tar
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tar
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tar/LICENSE
+├─ terser-webpack-plugin@1.4.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/terser-webpack-plugin
+│  ├─ publisher: webpack Contrib Team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/terser-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/terser-webpack-plugin/LICENSE
+├─ terser-webpack-plugin@4.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/terser-webpack-plugin
+│  ├─ publisher: webpack Contrib Team
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser-webpack-plugin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser-webpack-plugin/LICENSE
+├─ terser@4.8.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/terser/terser
+│  ├─ publisher: Mihai Bazon
+│  ├─ email: mihai.bazon@gmail.com
+│  ├─ url: http://lisperator.net/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser/LICENSE
+├─ terser@5.18.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/terser/terser
+│  ├─ publisher: Mihai Bazon
+│  ├─ email: mihai.bazon@gmail.com
+│  ├─ url: http://lisperator.net/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser-webpack-plugin/node_modules/terser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/terser-webpack-plugin/node_modules/terser/LICENSE
+├─ text-table@0.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/text-table
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/text-table
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/text-table/LICENSE
+├─ thenify-all@1.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thenables/thenify-all
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/thenify-all
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/thenify-all/LICENSE
+├─ thenify@3.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thenables/thenify
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/thenify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/thenify/LICENSE
+├─ thread-loader@2.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/thread-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-babel/node_modules/thread-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-babel/node_modules/thread-loader/LICENSE
+├─ throttle-debounce@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/niksy/throttle-debounce
+│  ├─ publisher: Ivan Nikolić
+│  ├─ email: niksy5@gmail.com
+│  ├─ url: http://ivannikolic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/throttle-debounce
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/throttle-debounce/LICENSE.md
+├─ throttle-debounce@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/niksy/throttle-debounce
+│  ├─ publisher: Ivan Nikolić
+│  ├─ email: niksy5@gmail.com
+│  ├─ url: http://ivannikolic.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/core-helpers/node_modules/throttle-debounce
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@remirror/core-helpers/node_modules/throttle-debounce/LICENSE.md
+├─ through2@2.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rvagg/through2
+│  ├─ publisher: Rod Vagg
+│  ├─ email: r@va.gg
+│  ├─ url: https://github.com/rvagg
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/through2
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/through2/LICENSE.md
+├─ through@2.3.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dominictarr/through
+│  ├─ publisher: Dominic Tarr
+│  ├─ email: dominic.tarr@gmail.com
+│  ├─ url: dominictarr.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/through
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/through/LICENSE.APACHE2
+├─ thunky@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/thunky
+│  ├─ publisher: Mathias Buus Madsen
+│  ├─ email: mathiasbuus@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/thunky
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/thunky/LICENSE
+├─ timers-browserify@2.0.12
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jryans/timers-browserify
+│  ├─ publisher: J. Ryan Stinnett
+│  ├─ email: jryans@gmail.com
+│  ├─ url: https://convolv.es/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/timers-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/timers-browserify/LICENSE.md
+├─ timsort@0.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mziccard/node-timsort
+│  ├─ publisher: Marco Ziccardi
+│  ├─ url: http://mziccard.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/timsort
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/timsort/LICENSE.md
+├─ tippy.js@6.3.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/atomiks/tippyjs
+│  ├─ publisher: atomiks
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tippy.js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tippy.js/LICENSE
+├─ tiptap-markdown@0.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/aguingand/tiptap-markdown
+│  ├─ publisher: Antoine Guingand
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tiptap-markdown
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tiptap-markdown/LICENSE
+├─ tmp@0.0.33
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/raszi/node-tmp
+│  ├─ publisher: KARASZI István
+│  ├─ email: github@spam.raszi.hu
+│  ├─ url: http://raszi.hu/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tmp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tmp/LICENSE
+├─ to-array@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/to-array
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-array
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-array/LICENCE
+├─ to-arraybuffer@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jhiesey/to-arraybuffer
+│  ├─ publisher: John Hiesey
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-arraybuffer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-arraybuffer/LICENSE
+├─ to-fast-properties@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/to-fast-properties
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-fast-properties
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-fast-properties/license
+├─ to-object-path@0.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/to-object-path
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-object-path
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-object-path/LICENSE
+├─ to-regex-range@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/to-regex-range
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch/node_modules/to-regex-range
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/micromatch/node_modules/to-regex-range/LICENSE
+├─ to-regex-range@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/to-regex-range
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-regex-range
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-regex-range/LICENSE
+├─ to-regex@3.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/to-regex
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-regex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/to-regex/LICENSE
+├─ toggle-selection@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sudodoki/toggle-selection
+│  ├─ publisher: sudodoki
+│  ├─ email: smd.deluzion@gmail.com
+│  ├─ url: sudodoki.name
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/toggle-selection
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/toggle-selection/README.md
+├─ toidentifier@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/component/toidentifier
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/toidentifier
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/toidentifier/LICENSE
+├─ toml@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/BinaryMuse/toml-node
+│  ├─ publisher: Michelle Tilley
+│  ├─ email: michelle@michelletilley.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/toml
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/toml/LICENSE
+├─ toposort@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/marcelklehr/toposort
+│  ├─ publisher: Marcel Klehr
+│  ├─ email: mklehr@gmx.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/toposort
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/toposort/License
+├─ totalist@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/totalist
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke.edwards05@gmail.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/totalist
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/totalist/license
+├─ tough-cookie@2.5.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/salesforce/tough-cookie
+│  ├─ publisher: Jeremy Stashewsky
+│  ├─ email: jstash@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tough-cookie
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tough-cookie/LICENSE
+├─ tr46@0.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Sebmaster/tr46.js
+│  ├─ publisher: Sebastian Mayr
+│  ├─ email: npm@smayr.name
+│  └─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tr46
+├─ tryer@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: git+https://gitlab.com/philbooth/tryer
+│  ├─ publisher: Phil Booth
+│  ├─ email: pmbooth@gmail.com
+│  ├─ url: https://philbooth.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tryer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tryer/COPYING
+├─ ts-pnp@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/arcanis/ts-pnp
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ts-pnp
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ts-pnp/README.md
+├─ tslib@1.14.1
+│  ├─ licenses: 0BSD
+│  ├─ repository: https://github.com/Microsoft/tslib
+│  ├─ publisher: Microsoft Corp.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tslib
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tslib/LICENSE.txt
+├─ tslib@2.5.3
+│  ├─ licenses: 0BSD
+│  ├─ repository: https://github.com/Microsoft/tslib
+│  ├─ publisher: Microsoft Corp.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/style-resources-loader/node_modules/tslib
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/style-resources-loader/node_modules/tslib/LICENSE.txt
+├─ tty-browserify@0.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/tty-browserify
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tty-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tty-browserify/LICENSE
+├─ tunnel-agent@0.6.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mikeal/tunnel-agent
+│  ├─ publisher: Mikeal Rogers
+│  ├─ email: mikeal.rogers@gmail.com
+│  ├─ url: http://www.futurealoof.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tunnel-agent
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tunnel-agent/LICENSE
+├─ turbo-darwin-arm64@1.10.3
+│  ├─ licenses: MPL-2.0
+│  ├─ repository: https://github.com/vercel/turbo
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/turbo-darwin-arm64
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/turbo-darwin-arm64/LICENSE
+├─ turbo@1.10.3
+│  ├─ licenses: MPL-2.0
+│  ├─ repository: https://github.com/vercel/turbo
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/turbo
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/turbo/LICENSE
+├─ tweetnacl@0.14.5
+│  ├─ licenses: Unlicense
+│  ├─ repository: https://github.com/dchest/tweetnacl-js
+│  ├─ publisher: TweetNaCl-js contributors
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tweetnacl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/tweetnacl/LICENSE
+├─ type-check@0.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gkz/type-check
+│  ├─ publisher: George Zahariev
+│  ├─ email: z@georgezahariev.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/type-check
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/type-check/LICENSE
+├─ type-fest@0.21.3
+│  ├─ licenses: (MIT OR CC0-1.0)
+│  ├─ repository: https://github.com/sindresorhus/type-fest
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/type-fest
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/type-fest/license
+├─ type-fest@0.6.0
+│  ├─ licenses: (MIT OR CC0-1.0)
+│  ├─ repository: https://github.com/sindresorhus/type-fest
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/read-pkg/node_modules/type-fest
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/read-pkg/node_modules/type-fest/license
+├─ type-fest@2.19.0
+│  ├─ licenses: (MIT OR CC0-1.0)
+│  ├─ repository: https://github.com/sindresorhus/type-fest
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/type-fest
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/type-fest/readme.md
+├─ type-is@1.6.18
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/type-is
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/type-is
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/type-is/LICENSE
+├─ typed-array-length@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/typed-array-length
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/typed-array-length
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/typed-array-length/LICENSE
+├─ typedarray@0.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/typedarray
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/typedarray
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/typedarray/LICENSE
+├─ typescript@4.9.5
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/Microsoft/TypeScript
+│  ├─ publisher: Microsoft Corp.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/typescript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/typescript/LICENSE.txt
+├─ ua-parser-js@1.0.35
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/faisalman/ua-parser-js
+│  ├─ publisher: Faisal Salman
+│  ├─ email: f@faisalman.com
+│  ├─ url: http://faisalman.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ua-parser-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ua-parser-js/license.md
+├─ uc.micro@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/markdown-it/uc.micro
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uc.micro
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uc.micro/LICENSE.txt
+├─ uglify-js@3.4.10
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/mishoo/UglifyJS2
+│  ├─ publisher: Mihai Bazon
+│  ├─ email: mihai.bazon@gmail.com
+│  ├─ url: http://lisperator.net/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uglify-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uglify-js/LICENSE
+├─ unbox-primitive@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/unbox-primitive
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unbox-primitive
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unbox-primitive/LICENSE
+├─ underscore@1.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jashkenas/underscore
+│  ├─ publisher: Jeremy Ashkenas
+│  ├─ email: jeremy@documentcloud.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/underscore
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/underscore/LICENSE
+├─ unicode-canonical-property-names-ecmascript@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unicode-canonical-property-names-ecmascript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unicode-canonical-property-names-ecmascript/LICENSE-MIT.txt
+├─ unicode-match-property-ecmascript@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/unicode-match-property-ecmascript
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unicode-match-property-ecmascript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unicode-match-property-ecmascript/LICENSE-MIT.txt
+├─ unicode-match-property-value-ecmascript@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/unicode-match-property-value-ecmascript
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unicode-match-property-value-ecmascript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unicode-match-property-value-ecmascript/LICENSE-MIT.txt
+├─ unicode-property-aliases-ecmascript@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/unicode-property-aliases-ecmascript
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unicode-property-aliases-ecmascript
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unicode-property-aliases-ecmascript/LICENSE-MIT.txt
+├─ union-value@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/union-value
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/union-value
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/union-value/LICENSE
+├─ uniq@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mikolalysenko/uniq
+│  ├─ publisher: Mikola Lysenko
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uniq
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uniq/LICENSE
+├─ uniqs@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fgnass/uniqs
+│  ├─ publisher: Felix Gnass
+│  ├─ email: fgnass@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uniqs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uniqs/README.md
+├─ unique-filename@1.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/iarna/unique-filename
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unique-filename
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unique-filename/LICENSE
+├─ unique-filename@3.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/unique-filename
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/unique-filename
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/make-fetch-happen/node_modules/unique-filename/LICENSE
+├─ unique-slug@2.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/iarna/unique-slug
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unique-filename/node_modules/unique-slug
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unique-filename/node_modules/unique-slug/LICENSE
+├─ unique-slug@4.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/unique-slug
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unique-slug
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unique-slug/LICENSE
+├─ universalify@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/RyanZim/universalify
+│  ├─ publisher: Ryan Zimmerman
+│  ├─ email: opensrc@ryanzim.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/universalify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/universalify/LICENSE
+├─ unpipe@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stream-utils/unpipe
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unpipe
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unpipe/LICENSE
+├─ unquote@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lakenen/node-unquote
+│  ├─ publisher: Cameron Lakenen
+│  ├─ email: cameron@lakenen.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unquote
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unquote/LICENSE
+├─ unset-value@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/unset-value
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unset-value
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/unset-value/LICENSE
+├─ upath@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/anodynos/upath
+│  ├─ publisher: Angelos Pikoulas
+│  ├─ email: agelos.pikoulas@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/upath
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/upath/LICENSE
+├─ update-browserslist-db@1.0.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/browserslist/update-db
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/update-browserslist-db
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/update-browserslist-db/LICENSE
+├─ upper-case@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/upper-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/upper-case
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/upper-case/LICENSE
+├─ uri-js@4.4.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/garycourt/uri-js
+│  ├─ publisher: Gary Court
+│  ├─ email: gary.court@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uri-js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uri-js/LICENSE
+├─ urix@0.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lydell/urix
+│  ├─ publisher: Simon Lydell
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/urix
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/urix/LICENSE
+├─ url-loader@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/url-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/url-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/url-loader/LICENSE
+├─ url-parse@1.5.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/unshiftio/url-parse
+│  ├─ publisher: Arnout Kazemier
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/url-parse
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/url-parse/LICENSE
+├─ url-polyfill@1.1.12
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lifaon74/url-polyfill
+│  ├─ publisher: valentin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/url-polyfill
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/url-polyfill/LICENSE
+├─ url@0.11.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/defunctzombie/node-url
+│  ├─ publisher: defunctzombie
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/url/LICENSE
+├─ use@3.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/use
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/use
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/use/LICENSE
+├─ util-deprecate@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/util-deprecate
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/util-deprecate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/util-deprecate/LICENSE
+├─ util.promisify@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/util.promisify
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/util.promisify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/util.promisify/LICENSE
+├─ util.promisify@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/util.promisify
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/util.promisify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/util.promisify/LICENSE
+├─ util@0.10.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/defunctzombie/node-util
+│  ├─ publisher: Joyent
+│  ├─ url: http://www.joyent.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/util
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/util/LICENSE
+├─ util@0.11.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/defunctzombie/node-util
+│  ├─ publisher: Joyent
+│  ├─ url: http://www.joyent.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser/node_modules/util
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/node-libs-browser/node_modules/util/LICENSE
+├─ utila@0.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/AriaMinaei/utila
+│  ├─ publisher: Aria Minaei
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/utila
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/utila/LICENSE
+├─ utils-merge@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jaredhanson/utils-merge
+│  ├─ publisher: Jared Hanson
+│  ├─ email: jaredhanson@gmail.com
+│  ├─ url: http://www.jaredhanson.net/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/utils-merge
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/utils-merge/LICENSE
+├─ uuid-validate@0.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/WatchBeam/uuid-validate
+│  ├─ publisher: Connor Peet
+│  ├─ email: connor@connorpeet.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uuid-validate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uuid-validate/LICENSE
+├─ uuid@3.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/uuidjs/uuid
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uuid
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/uuid/LICENSE.md
+├─ uuid@8.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/uuidjs/uuid
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sockjs/node_modules/uuid
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/sockjs/node_modules/uuid/LICENSE.md
+├─ v-animate-css@0.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jofftiquez/v-animate-css
+│  ├─ publisher: jofftiquez@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/v-animate-css
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/v-animate-css/README.md
+├─ v-viewer@1.6.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mirari/v-viewer
+│  ├─ publisher: mirari
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/v-viewer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/v-viewer/LICENSE
+├─ v8-compile-cache@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zertosh/v8-compile-cache
+│  ├─ publisher: Andres Suarez
+│  ├─ email: zertosh@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/v8-compile-cache
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/v8-compile-cache/LICENSE
+├─ validate-npm-package-license@3.0.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/kemitchell/validate-npm-package-license.js
+│  ├─ publisher: Kyle E. Mitchell
+│  ├─ email: kyle@kemitchell.com
+│  ├─ url: https://kemitchell.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/validate-npm-package-license
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/validate-npm-package-license/LICENSE
+├─ validator@13.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/validatorjs/validator.js
+│  ├─ publisher: Chris O'Hara
+│  ├─ email: cohara87@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/validator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/validator/LICENSE
+├─ vary@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/vary
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vary
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vary/LICENSE
+├─ vee-validate@3.4.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/logaretm/vee-validate
+│  ├─ publisher: Abdelrahman Awad
+│  ├─ email: logaretm1@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vee-validate
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vee-validate/LICENSE
+├─ vendors@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/wooorm/vendors
+│  ├─ publisher: Titus Wormer
+│  ├─ email: tituswormer@gmail.com
+│  ├─ url: https://wooorm.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vendors
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vendors/license
+├─ verror@1.10.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/davepacheco/node-verror
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/verror
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/verror/LICENSE
+├─ viewerjs@1.11.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fengyuanchen/viewerjs
+│  ├─ publisher: Chen Fengyuan
+│  ├─ url: https://chenfengyuan.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/viewerjs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/viewerjs/LICENSE
+├─ vm-browserify@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/vm-browserify
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vm-browserify
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vm-browserify/LICENSE
+├─ vue-apexcharts@1.6.2
+│  ├─ licenses: MIT
+│  ├─ publisher: Juned Chhipa
+│  ├─ email: juned.chhipa@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-apexcharts
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-apexcharts/LICENSE
+├─ vue-awesome-swiper@4.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/surmon-china/vue-awesome-swiper
+│  ├─ publisher: Surmon
+│  ├─ url: https://github.com/surmon-china
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-awesome-swiper
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-awesome-swiper/LICENSE
+├─ vue-breakpoint-mixin@1.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ajomuch92/vue-breakpoint-mixin
+│  ├─ publisher: Aarón Montes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-breakpoint-mixin
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-breakpoint-mixin/LICENSE
+├─ vue-class-component@7.2.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-class-component
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-class-component
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-class-component/LICENSE
+├─ vue-cli-plugin-buefy@0.3.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/buefy/vue-cli-plugin-buefy
+│  ├─ publisher: anteriovieira
+│  ├─ email: anteriovieira@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-cli-plugin-buefy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-cli-plugin-buefy/LICENSE
+├─ vue-codemirror@4.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/surmon-china/vue-codemirror
+│  ├─ publisher: Surmon
+│  ├─ email: surmon@foxmail.com
+│  ├─ url: https://surmon.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-codemirror
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-codemirror/LICENSE
+├─ vue-custom-scrollbar@1.4.4
+│  ├─ licenses: MIT*
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-custom-scrollbar
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-custom-scrollbar/LICENSE
+├─ vue-ellipse-progress@1.3.1
+│  ├─ licenses: MIT*
+│  ├─ repository: https://github.com/setaman/vue-ellipse-progress
+│  ├─ publisher: Sergej Atamantschuk
+│  ├─ email: sergejatam@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-ellipse-progress
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-ellipse-progress/LICENSE
+├─ vue-eslint-parser@8.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-eslint-parser
+│  ├─ publisher: Toru Nagashima
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-eslint-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-eslint-parser/LICENSE
+├─ vue-fullscreen@2.6.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/mirari/vue-fullscreen
+│  ├─ publisher: mirari
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-fullscreen
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-fullscreen/LICENSE
+├─ vue-hot-reload-api@2.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-hot-reload-api
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-hot-reload-api
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-hot-reload-api/LICENSE
+├─ vue-i18n@8.28.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kazupon/vue-i18n
+│  ├─ publisher: kazuya kawaguchi
+│  ├─ email: kawakazu80@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-i18n
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-i18n/LICENSE
+├─ vue-loader@15.10.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-loader
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/vue-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/vue-loader/LICENSE
+├─ vue-loader@16.8.3
+│  ├─ licenses: MIT
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/vue-loader-v16
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/vue-loader-v16/LICENSE
+├─ vue-pdf@4.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/FranckFreiburger/vue-pdf
+│  ├─ publisher: Franck FREIBURGER
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-pdf
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-pdf/LICENSE
+├─ vue-plyr@7.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/redxtech/vue-plyr
+│  ├─ publisher: Gabe Dunn
+│  ├─ email: gabe@redxtech.ca
+│  ├─ url: https://gabedunn.dev
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-plyr
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-plyr/LICENSE.md
+├─ vue-popperjs@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/RobinCK/vue-popper
+│  ├─ publisher: Igor Ognichenko
+│  ├─ email: ognichenko.igor@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-popperjs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-popperjs/LICENSE
+├─ vue-property-decorator@8.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kaorun343/vue-property-decorator
+│  ├─ publisher: kaorun343
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-property-decorator
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-property-decorator/LICENSE
+├─ vue-resize-sensor@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/FranckFreiburger/vue-resize-sensor
+│  ├─ publisher: Franck FREIBURGER
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-resize-sensor
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-resize-sensor/LICENSE
+├─ vue-router@3.6.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-router
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-router
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-router/LICENSE
+├─ vue-slider-component@3.2.24
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/NightCatSama/vue-slider-component
+│  ├─ publisher: NightCatSama
+│  ├─ email: 642163903@qq.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-slider-component
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-slider-component/LICENSE
+├─ vue-smooth-reflow@0.1.12
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/guanzo/vue-smooth-reflow
+│  ├─ publisher: guanzo guanzo91@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-smooth-reflow
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-smooth-reflow/README.md
+├─ vue-social-sharing@3.0.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nicolasbeauvais/vue-social-sharing
+│  ├─ publisher: Nicolas Beauvais
+│  ├─ email: nicolas@bvs.email
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-social-sharing
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-social-sharing/LICENSE
+├─ vue-socket.io-extended@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/probil/vue-socket.io-extended
+│  ├─ publisher: Max Lyashuk
+│  ├─ email: m_lyashuk@ukr.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-socket.io-extended
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-socket.io-extended/LICENSE
+├─ vue-style-loader@4.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-style-loader
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-style-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-style-loader/LICENSE
+├─ vue-template-compiler@2.7.14
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-template-compiler
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-template-compiler/LICENSE
+├─ vue-template-es2015-compiler@1.9.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue-template-es2015-compiler
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-template-es2015-compiler
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue-template-es2015-compiler/README.md
+├─ vue2-touch-events@3.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jerrybendy/vue-touch-events
+│  ├─ publisher: Jerry Bendy
+│  ├─ email: jerry@icewingcc.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue2-touch-events
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue2-touch-events/LICENSE
+├─ vue@2.7.14
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vue
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vue/LICENSE
+├─ vuedraggable@2.24.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/SortableJS/Vue.Draggable
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vuedraggable
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vuedraggable/LICENSE
+├─ vuex@3.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vuejs/vuex
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vuex
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/vuex/LICENSE
+├─ w3c-keyname@2.2.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/marijnh/w3c-keyname
+│  ├─ publisher: Marijn Haverbeke
+│  ├─ email: marijn@haverbeke.berlin
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/w3c-keyname
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/w3c-keyname/LICENSE
+├─ watchpack-chokidar2@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/watchpack
+│  ├─ publisher: Tobias Koppers @sokra
+│  └─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack-chokidar2
+├─ watchpack@1.7.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/watchpack
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/watchpack/LICENSE
+├─ wbuf@1.7.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/wbuf
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wbuf
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wbuf/README.md
+├─ wcwidth@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/timoxley/wcwidth
+│  ├─ publisher: Tim Oxley
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wcwidth
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wcwidth/LICENSE
+├─ webidl-conversions@3.0.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/jsdom/webidl-conversions
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webidl-conversions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webidl-conversions/LICENSE.md
+├─ webpack-bundle-analyzer@3.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/webpack-bundle-analyzer
+│  ├─ publisher: Yury Grunin
+│  ├─ email: grunin.ya@ya.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/webpack-bundle-analyzer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/webpack-bundle-analyzer/LICENSE
+├─ webpack-bundle-analyzer@4.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/webpack-bundle-analyzer
+│  ├─ publisher: Yury Grunin
+│  ├─ email: grunin.ya@ya.ru
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-bundle-analyzer
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-bundle-analyzer/LICENSE
+├─ webpack-chain@4.12.1
+│  ├─ licenses: MPL-2.0
+│  ├─ repository: https://github.com/neutrinojs/webpack-chain
+│  ├─ publisher: Eli Perelman
+│  ├─ email: eli@eliperelman.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-chain
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-chain/LICENSE
+├─ webpack-chain@6.5.1
+│  ├─ licenses: MPL-2.0
+│  ├─ repository: https://github.com/neutrinojs/webpack-chain
+│  ├─ publisher: Eli Perelman
+│  ├─ email: eli@eliperelman.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/webpack-chain
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/webpack-chain/LICENSE
+├─ webpack-cli@4.10.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-cli
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli/LICENSE
+├─ webpack-dev-middleware@3.7.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-dev-middleware
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/webpack-dev-middleware
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/webpack-dev-middleware/LICENSE
+├─ webpack-dev-server@3.11.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-dev-server
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/webpack-dev-server
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/webpack-dev-server/LICENSE
+├─ webpack-log@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/webpack-log
+│  ├─ publisher: Andrew Powell
+│  ├─ email: andrew@shellscape.org
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-log
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-log/LICENSE
+├─ webpack-merge@4.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/survivejs/webpack-merge
+│  ├─ publisher: Juho Vepsalainen
+│  ├─ email: bebraw@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-merge
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-merge/LICENSE
+├─ webpack-merge@5.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/survivejs/webpack-merge
+│  ├─ publisher: Juho Vepsalainen
+│  ├─ email: bebraw@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli/node_modules/webpack-merge
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-cli/node_modules/webpack-merge/LICENSE
+├─ webpack-sources@1.4.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-sources
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-sources
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-sources/LICENSE
+├─ webpack@4.36.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack/LICENSE
+├─ webpack@4.46.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/webpack
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-plugin-eslint/node_modules/webpack/LICENSE
+├─ websocket-driver@0.7.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/faye/websocket-driver-node
+│  ├─ publisher: James Coglan
+│  ├─ email: jcoglan@gmail.com
+│  ├─ url: http://jcoglan.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/websocket-driver
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/websocket-driver/LICENSE.md
+├─ websocket-extensions@0.1.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/faye/websocket-extensions-node
+│  ├─ publisher: James Coglan
+│  ├─ email: jcoglan@gmail.com
+│  ├─ url: http://jcoglan.com/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/websocket-extensions
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/websocket-extensions/LICENSE.md
+├─ whatwg-url@5.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/whatwg-url
+│  ├─ publisher: Sebastian Mayr
+│  ├─ email: github@smayr.name
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/whatwg-url
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/whatwg-url/LICENSE.txt
+├─ which-boxed-primitive@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/which-boxed-primitive
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/which-boxed-primitive
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/which-boxed-primitive/LICENSE
+├─ which-module@2.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/nexdrew/which-module
+│  ├─ publisher: nexdrew
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/which-module
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/which-module/LICENSE
+├─ which-typed-array@1.1.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/which-typed-array
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/which-typed-array
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/which-typed-array/LICENSE
+├─ which@1.3.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-which
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/which
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/which/LICENSE
+├─ which@2.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-which
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn/node_modules/which
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/cross-spawn/node_modules/which/LICENSE
+├─ wide-align@1.1.5
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/iarna/wide-align
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wide-align
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wide-align/LICENSE
+├─ wildcard@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DamonOehlman/wildcard
+│  ├─ publisher: Damon Oehlman
+│  ├─ email: damon.oehlman@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wildcard
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wildcard/LICENSE
+├─ word-wrap@1.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/word-wrap
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/word-wrap
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/word-wrap/LICENSE
+├─ worker-farm@1.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rvagg/node-worker-farm
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/worker-farm
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/worker-farm/LICENSE.md
+├─ worker-loader@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/worker-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/worker-loader
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/worker-loader/LICENSE
+├─ wrap-ansi@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/wrap-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/yargs/node_modules/wrap-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/yargs/node_modules/wrap-ansi/license
+├─ wrap-ansi@6.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/wrap-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/wrap-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/wrap-ansi/license
+├─ wrap-ansi@7.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/wrap-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wrap-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wrap-ansi/license
+├─ wrap-ansi@8.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/wrap-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/wrap-ansi
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@isaacs/cliui/node_modules/wrap-ansi/license
+├─ wrappy@1.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/wrappy
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wrappy
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/wrappy/LICENSE
+├─ write@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/write
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/write
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/write/LICENSE
+├─ ws@6.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/websockets/ws
+│  ├─ publisher: Einar Otto Stangvik
+│  ├─ email: einaros@gmail.com
+│  ├─ url: http://2x.io
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ws
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/ws/LICENSE
+├─ ws@7.4.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/websockets/ws
+│  ├─ publisher: Einar Otto Stangvik
+│  ├─ email: einaros@gmail.com
+│  ├─ url: http://2x.io
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/engine.io-client/node_modules/ws
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/engine.io-client/node_modules/ws/LICENSE
+├─ ws@7.5.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/websockets/ws
+│  ├─ publisher: Einar Otto Stangvik
+│  ├─ email: einaros@gmail.com
+│  ├─ url: http://2x.io
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-bundle-analyzer/node_modules/ws
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/webpack-bundle-analyzer/node_modules/ws/LICENSE
+├─ xml2js@0.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Leonidas-from-XIV/node-xml2js
+│  ├─ publisher: Marek Kubica
+│  ├─ email: marek@xivilization.net
+│  ├─ url: https://xivilization.net
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xml2js
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xml2js/LICENSE
+├─ xml@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dylang/node-xml
+│  ├─ publisher: Dylan Greene
+│  ├─ url: https://github.com/dylang
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xml
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xml/LICENSE
+├─ xmlbuilder@11.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/oozcitak/xmlbuilder-js
+│  ├─ publisher: Ozgur Ozcitak
+│  ├─ email: oozcitak@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xmlbuilder
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xmlbuilder/LICENSE
+├─ xmlhttprequest-ssl@1.6.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mjwwit/node-XMLHttpRequest
+│  ├─ publisher: Michael de Wit
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xmlhttprequest-ssl
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xmlhttprequest-ssl/LICENSE
+├─ xss@1.0.14
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/leizongmin/js-xss
+│  ├─ publisher: Zongmin Lei
+│  ├─ email: leizongmin@gmail.com
+│  ├─ url: http://ucdok.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xss
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xss/LICENSE
+├─ xtend@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/xtend
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xtend
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xtend/LICENSE
+├─ xterm-addon-attach@0.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtermjs/xterm.js
+│  ├─ publisher: The xterm.js authors
+│  ├─ url: https://xtermjs.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xterm-addon-attach
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xterm-addon-attach/LICENSE
+├─ xterm-addon-fit@0.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtermjs/xterm.js
+│  ├─ publisher: The xterm.js authors
+│  ├─ url: https://xtermjs.org/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xterm-addon-fit
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xterm-addon-fit/LICENSE
+├─ xterm@4.19.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtermjs/xterm.js
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xterm
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/xterm/LICENSE
+├─ y18n@4.0.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/y18n
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/y18n
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/y18n/LICENSE
+├─ y18n@5.0.8
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/y18n
+│  ├─ publisher: Ben Coe
+│  ├─ email: bencoe@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yargs/node_modules/y18n
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yargs/node_modules/y18n/LICENSE
+├─ yallist@2.1.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/yallist
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils/node_modules/yallist
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/component-compiler-utils/node_modules/yallist/LICENSE
+├─ yallist@3.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/yallist
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lru-cache/node_modules/yallist
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/lru-cache/node_modules/yallist/LICENSE
+├─ yallist@4.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/yallist
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yallist
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yallist/LICENSE
+├─ yaml@1.10.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/eemeli/yaml
+│  ├─ publisher: Eemeli Aro
+│  ├─ email: eemeli@gmail.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yaml
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yaml/LICENSE
+├─ yamljs@0.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jeremyfa/yaml.js
+│  ├─ publisher: Jeremy Faivre
+│  ├─ email: contact@jeremyfa.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yamljs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yamljs/LICENSE
+├─ yargs-parser@11.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/yargs-parser
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/composerize/node_modules/yargs-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/composerize/node_modules/yargs-parser/LICENSE.txt
+├─ yargs-parser@13.1.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/yargs-parser
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/yargs-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/yargs-parser/LICENSE.txt
+├─ yargs-parser@20.2.9
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/yargs-parser
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yargs/node_modules/yargs-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yargs/node_modules/yargs-parser/LICENSE.txt
+├─ yargs-parser@21.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/yargs-parser
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yargs-parser
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yargs-parser/LICENSE.txt
+├─ yargs@13.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/yargs/yargs
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/yargs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/@vue/cli-service/node_modules/yargs/LICENSE
+├─ yargs@16.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/yargs/yargs
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yargs
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yargs/LICENSE
+├─ yeast@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/unshiftio/yeast
+│  ├─ publisher: Arnout Kazemier
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yeast
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yeast/LICENSE
+├─ yocto-queue@0.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/yocto-queue
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yocto-queue
+│  └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yocto-queue/license
+└─ yorkie@2.0.0
+   ├─ licenses: MIT
+   ├─ repository: https://github.com/yyx990803/yorkie
+   ├─ path: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie
+   └─ licenseFile: /Users/zhanghengxin/WebstormProjects/CasaOS-UI/node_modules/yorkie/LICENSE
+

--- a/main/src/components/Apps/AppDetailInfo.vue
+++ b/main/src/components/Apps/AppDetailInfo.vue
@@ -253,7 +253,7 @@ export default {
 				hasModalCard: true,
 				destroyOnHide: true,
 				animation: "zoom-in",
-				canCancel: ["escape", "x"]
+				canCancel: ["escape", "outside", "x"]
 			});
 		}
 	}

--- a/main/src/components/Apps/AppDetailInfo.vue
+++ b/main/src/components/Apps/AppDetailInfo.vue
@@ -104,8 +104,8 @@
 						<div class="gap">
 							<b-image :src="item"
 									 :src-fallback="require('@/assets/img/app/swiper_placeholder.png')"
-									 @click.native="zoomScreenshot(item)"
-									 class="border-8" placeholder ratio="16by9"></b-image>
+									 class="border-8"
+									 placeholder ratio="16by9" @click.native="zoomScreenshot(item)"></b-image>
 						</div>
 					</swiper-slide>
 
@@ -239,16 +239,16 @@ export default {
 			return tempO.font;
 		},
 		zoomScreenshot(img) {
-			const customVNode = this.$createElement('div', { 
-									class: 'modal-content' 
-								}, [
-									this.$createElement('img', { attrs: { src: img } })
-								]);
-								
+			const customVNode = this.$createElement('div', {
+				class: 'modal-content'
+			}, [
+				this.$createElement('img', {attrs: {src: img}})
+			]);
+
 
 			this.$buefy.modal.open({
 				content: [customVNode],
-				customClass: 'zoom-screenshot',
+				customClass: '_zoom-screenshot',
 				fullScreen: true,
 				hasModalCard: true,
 				destroyOnHide: true,
@@ -261,33 +261,34 @@ export default {
 </script>
 
 <style lang="scss">
-	.modal.zoom-screenshot {
+//The underscore "_" here represents that it is only used in this context and needs to be placed in the modularized CSS later.
+.modal._zoom-screenshot {
 
-		.animation-content {
-			display: flex;
-			align-items: center;
-		}
-
-		.modal-content {
-			width: auto;
-			overflow: unset;
-
-			img {
-				max-width: 90vw;
-				max-height: 90vh;
-				border: 3px solid #ccc;
-				border-radius: 1rem;
-				box-shadow: 0 0 40px 0 rgba(255,255,255,0.5);
-			}
-		}
-
-		.modal-close {
-			position: absolute;
-
-			&::before, &::after {
-				background: #fff;
-			}
-		}
-
+	.animation-content {
+		display: flex;
+		align-items: center;
 	}
+
+	.modal-content {
+		width: auto;
+		overflow: unset;
+
+		img {
+			max-width: 90vw;
+			max-height: 90vh;
+			border: 3px solid #ccc;
+			border-radius: 1rem;
+			box-shadow: 0 0 40px 0 rgba(255, 255, 255, 0.5);
+		}
+	}
+
+	.modal-close {
+		position: absolute;
+
+		&::before, &::after {
+			background: #fff;
+		}
+	}
+
+}
 </style>

--- a/main/src/components/Apps/AppDetailInfo.vue
+++ b/main/src/components/Apps/AppDetailInfo.vue
@@ -104,6 +104,7 @@
 						<div class="gap">
 							<b-image :src="item"
 									 :src-fallback="require('@/assets/img/app/swiper_placeholder.png')"
+									 @click.native="zoomScreenshot(item)"
 									 class="border-8" placeholder ratio="16by9"></b-image>
 						</div>
 					</swiper-slide>
@@ -237,11 +238,56 @@ export default {
 			let tempO = this.cateMenu.find(item => item.name == name) || {font: 'apps'}
 			return tempO.font;
 		},
+		zoomScreenshot(img) {
+			const customVNode = this.$createElement('div', { 
+									class: 'modal-content' 
+								}, [
+									this.$createElement('img', { attrs: { src: img } })
+								]);
+								
 
+			this.$buefy.modal.open({
+				content: [customVNode],
+				customClass: 'zoom-screenshot',
+				fullScreen: true,
+				hasModalCard: true,
+				destroyOnHide: true,
+				animation: "zoom-in",
+				canCancel: ["escape", "x"]
+			});
+		}
 	}
 }
 </script>
 
-<style scoped>
+<style lang="scss">
+	.modal.zoom-screenshot {
 
+		.animation-content {
+			display: flex;
+			align-items: center;
+		}
+
+		.modal-content {
+			width: auto;
+			overflow: unset;
+
+			img {
+				max-width: 90vw;
+				max-height: 90vh;
+				border: 3px solid #ccc;
+				border-radius: 1rem;
+				box-shadow: 0 0 40px 0 rgba(255,255,255,0.5);
+			}
+		}
+
+		.modal-close {
+			position: absolute;
+
+			&::before, &::after {
+				background: #fff;
+			}
+		}
+
+	}
 </style>


### PR DESCRIPTION
**Reason for Implementation:**

In current behavior, when a screenshot image is clicked, nothing happens. UX-wise, the user expects the image to enlarge when the images are clicked.

**Screenshots:**

![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/a6d47fd9-24f9-4e34-aac0-353d55d649e9)
![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/370cecc5-70ee-4cd1-aac9-ec36c563924f)
![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/8d56508a-0dfd-45ff-81fc-a44edcc83136)

---

![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/e1b60463-c272-4ff1-bb04-80dda3efba66)
![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/f6e2987b-5fbd-49ef-b91b-30ee9315677a)
![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/8f887cd7-a361-4d9a-9d01-993da9a0ced5)


---
![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/e5659744-7298-43e3-b28b-66dbadc96564)
![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/f315aca7-b320-443b-b775-483607c9321f)
![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/e94ca327-262f-4d6f-9bc4-bc737cf54384)


