### PR TITLE
🐛  Fix restart policy

### DIFF
--- a/main/src/components/Apps/ComposeConfig.vue
+++ b/main/src/components/Apps/ComposeConfig.vue
@@ -708,7 +708,7 @@ export default {
 			if (composeServicesItemInput.restart != undefined) {
 				composeServicesItem.restart = composeServicesItemInput.restart;
 			}
-			composeServicesItem.restart = composeServicesItem.restart === "no" ? "unless-stopped" : composeServicesItem.restart;
+			composeServicesItem.restart = (composeServicesItem.restart === "no" || !composeServicesItem.restart) ? "unless-stopped" : composeServicesItem.restart;
 
 			// command
 			composeServicesItem.command = this.makeArray(composeServicesItemInput.command)


### PR DESCRIPTION
Fixes an issue in ComposeConfig.vue where the restart behavior was not handled correctly. Previously, if `composeServicesItem.restart` was equal to "no" or undefined, it would not set the value to "unless-stopped". This update fixes that by checking if `composeServicesItem.restart` is equal to "no" or not defined, and assigns "unless-stopped" to it.