### PR TITLE
Change file extension of exported compose file to ".yml"

### DIFF
--- a/main/src/components/Apps/AppCard.vue
+++ b/main/src/components/Apps/AppCard.vue
@@ -600,7 +600,7 @@ export default {
 		exportYAML(item) {
 			this.$api.container.exportAsCompose(item.name).then(res => {
 				const blob = new Blob([res.data], {type: ''});
-				FileSaver.saveAs(blob, `${item.image}.yaml`);
+				FileSaver.saveAs(blob, `${item.image}.yml`);
 			}).catch((err) => {
 				this.$buefy.toast.open({
 					message: err.response.data.message,

--- a/main/src/components/Apps/AppPanel.vue
+++ b/main/src/components/Apps/AppPanel.vue
@@ -1332,7 +1332,7 @@ export default {
 				title = this.currentInstallId
 			}
 			const blob = new Blob([this.dockerComposeCommands], {type: ''});
-			FileSaver.saveAs(blob, `${title}.yaml`);
+			FileSaver.saveAs(blob, `${title}.yml`);
 		},
 
 		/**


### PR DESCRIPTION
I ran into a tricky issue when trying to create my own AppStore with my custom apps. 

I exported their compose files from the settings view, and that created a "appname.**yaml**" file. So far, so good.
However the AppStore loader only accepts ".yml" files (without the a), which was an easy thing to miss and lead me to long debugging...

Maybe this little change will prevent other people from having the same issue.