### PR TITLE
fix: the privileged always is true

### DIFF
--- a/main/src/components/Apps/ComposeConfig.vue
+++ b/main/src/components/Apps/ComposeConfig.vue
@@ -833,7 +833,7 @@ export default {
 					}
 					return false
 				}).map((env) => {
-					return `${env.container}:${env.host}`;
+					return `${env.container}=${env.host}`;
 				});
 			}
 			if (this.dockerComposeCommands) {

--- a/main/src/components/Apps/ComposeConfig.vue
+++ b/main/src/components/Apps/ComposeConfig.vue
@@ -571,6 +571,7 @@ export default {
 				this.configData["x-casaos"] = merge(this.configData["x-casaos"], yaml["x-casaos"]);
 
 			} catch (error) {
+				console.log()
 				console.log(error);
 			}
 		},
@@ -696,8 +697,10 @@ export default {
 
 			//hostname
 			// configData.host_name = parsedInput.hostname != undefined ? parsedInput.hostname : ""
+			
 			// privileged
-			composeServicesItem.privileged = composeServicesItemInput.privileged != undefined;
+			// relation issue: https://github.com/IceWhaleTech/CasaOS/issues/1264
+			composeServicesItem.privileged = (composeServicesItemInput.privileged == true);
 
 			//cap-add
 			if (composeServicesItemInput.cap_add != undefined) {
@@ -830,7 +833,7 @@ export default {
 					}
 					return false
 				}).map((env) => {
-					return `${env.container}=${env.host}`;
+					return `${env.container}:${env.host}`;
 				});
 			}
 			if (this.dockerComposeCommands) {

--- a/main/src/components/Apps/ComposeConfig.vue
+++ b/main/src/components/Apps/ComposeConfig.vue
@@ -700,7 +700,8 @@ export default {
 			
 			// privileged
 			// relation issue: https://github.com/IceWhaleTech/CasaOS/issues/1264
-			composeServicesItem.privileged = (composeServicesItemInput.privileged == true);
+			// if privileged is undefined or false, set it to false.
+			composeServicesItem.privileged = composeServicesItemInput.privileged;
 
 			//cap-add
 			if (composeServicesItemInput.cap_add != undefined) {

--- a/main/src/components/Apps/ComposeConfig.vue
+++ b/main/src/components/Apps/ComposeConfig.vue
@@ -571,7 +571,6 @@ export default {
 				this.configData["x-casaos"] = merge(this.configData["x-casaos"], yaml["x-casaos"]);
 
 			} catch (error) {
-				console.log()
 				console.log(error);
 			}
 		},


### PR DESCRIPTION
# What does the PR do?
fix the logic of privileged cal

close https://github.com/IceWhaleTech/CasaOS/issues/1264

## Test Sample

privileged should be false 
```yaml
name: memos
services:
  memos:
    environment:
      PGID: $PGID
      PUID: $PUID
      TZ: $TZ
    image: neosmemo/memos:0.14.0
    deploy:
      resources:
        reservations:
          memory: 64M
    network_mode: bridge
    ports:
      - target: 5230
        published: "5230"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: bind
        source: /DATA/AppData/memos/memos
        target: /var/opt/memos
    x-casaos:
      envs:
        - container: PUID
          description:
            en_us: ""
        - container: PGID
          description:
            en_us: ""
        - container: TZ
          description:
            en_us: "timezone"
            zh_cn: "时区"
      ports:
        - container: "5230"
          description:
            en_us: WebUI HTTP Port
            zh_cn: WebUI HTTP 端口
      volumes:
        - container: /var/opt/memos
          description:
            en_us: memos data directory.
            zh_cn: memos 数据目录

x-casaos:
  architectures:
    - amd64
    - arm64
    - arm
  main: memos
  author: usememos Team
  category: Notes
  description:
    en_us: Memos is a lightweight, self-hosted memo hub. Open Source and Free forever.
    zh_cn: Memos 是一个轻量级的自托管Memos中心。 开源且永远免费。
  developer: usememos Team
  icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/icon.png
  screenshot_link:
    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/screenshot-1.png
    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/screenshot-2.png
  tagline:
    en_us: Memos is a lightweight, self-hosted memo hub. Open Source and Free forever.
    zh_cn: Memos 是一个轻量级的自托管Memos中心。 开源且永远免费。
  thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/thumbnail.png
  tips: {}
  title:
    en_us: Memos
  port_map: "5230"
```

privileged should be true
```
name: snapdrop
services:
  snapdrop:
    environment:
      - PGID=$PGID
      - PUID=$PUID
      - TZ=$TZ
    image: lscr.io/linuxserver/snapdrop:version-eac78009
    network_mode: bridge
    ports:
      - target: 443
        published: "443"
        protocol: tcp
      - target: 80
        published: "89"
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: bind
        source: /DATA/AppData/$AppID/config
        target: /config
    privileged: true
x-casaos:
  architectures:
    - amd64
    - arm64
    - arm
  description:
    en_us: Snapdrop is a Progressive Web App (PWA) that allows you to transfer files between devices in the same network without having to install anything.
    zh_cn: Snapdrop是一个渐进式Web应用程序（PWA），允许您在同一网络中的设备之间传输文件，而无需安装任何内容。
    ar_sa: Snapdrop هو تطبيق ويب تدريجي (PWA) يتيح لك نقل الملفات بين الأجهزة في نفس الشبكة دون الحاجة إلى تثبيت أي شيء.
    de_de: Snapdrop ist eine Progressive Web App (PWA), mit der Sie Dateien zwischen Geräten im selben Netzwerk übertragen können, ohne etwas installieren zu müssen.
    es_es: Snapdrop es una aplicación web progresiva (PWA) que le permite transferir archivos entre dispositivos en la misma red sin tener que instalar nada.
    fr_fr: Snapdrop est une application Web progressive (PWA) qui vous permet de transférer des fichiers entre des appareils sur le même réseau sans avoir à installer quoi que ce soit.
    hu_hu: A Snapdrop egy progresszív webalkalmazás (PWA), amely lehetővé teszi a fájlok átvitelét a hálózaton belüli eszközök között anélkül, hogy telepítenie kellene bármit is.
    it_it: Snapdrop è un'app Web progressiva (PWA) che consente di trasferire file tra dispositivi nella stessa rete senza dover installare nulla.
    ru_ru: Snapdrop - это прогрессивное веб-приложение (PWA), которое позволяет передавать файлы между устройствами в одной сети без необходимости устанавливать что-либо.
    pl_pl: Snapdrop to progresywna aplikacja internetowa (PWA), która umożliwia przesyłanie plików między urządzeniami w tej samej sieci bez konieczności instalowania czegokolwiek.
    pt_br: Snapdrop é um aplicativo da Web progressivo (PWA) que permite transferir arquivos entre dispositivos na mesma rede sem precisar instalar nada.
    sv_se: Snapdrop är en progressiv webbapp (PWA) som låter dig överföra filer mellan enheter i samma nätverk utan att behöva installera något.
    uk_ua: Snapdrop - це прогресивний веб-додаток (PWA), який дозволяє передавати файли між пристроями в одній мережі без необхідності встановлювати що-небудь.
  icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Snapdrop/icon.png
  screenshot_link:
    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Snapdrop/screenshot-1.png
  tagline:
    en_us: Cross-platform file sharing made easy.
    zh_cn: 轻松实现跨平台文件共享。
    ar_sa: تبادل الملفات عبر المنصات بكل سهولة.
    de_de: Einfacher plattformübergreifender Dateiaustausch.
    es_es: Compartir archivos entre plataformas nunca fue tan fácil.
    fr_fr: Partage de fichiers multiplateforme simplifié.
    hu_hu: Egyszerűsített többplatformos fájlmegosztás.
    it_it: Condivisione di file multi-piattaforma resa facile.
    ru_ru: Простой обмен файлами между платформами.
    pl_pl: Proste udostępnianie plików międzyplatformowych.
    pt_br: Compartilhamento de arquivos entre plataformas feito fácil.
    sv_se: Enkel filöverföring mellan olika plattformar.
    uk_ua: Проста пересилка файлів між платформами.
  author: self
  category: Utilities
  hostname: ""
  index: /
  port_map: "89"
  scheme: http
  store_app_id: snapdrop
  title:
    en_us: snapdrop
```

privileged should be false
```yml
name: openspeedtest
services:
  openspeedtest:
    deploy:
      resources:
        reservations:
          memory: "67108864"
        limits:
          memory: 23988M
    image: openspeedtest/latest:v0.0.1
    labels:
      icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenSpeedTest/icon.png
    ports:
      - target: 3000
        published: "3004"
        protocol: tcp
    restart: always
    x-casaos:
      ports:
        - container: "3000"
          description:
            en_us: ""
    volumes: []
    devices: []
    cap_add: []
    command: []
    environment: []
    network_mode: bridge
    privileged: false
    container_name: ""
    cpu_shares: 90
```