### PR TITLE
chore: delete unnecessary dep

### DIFF
--- a/main/package.json
+++ b/main/package.json
@@ -95,7 +95,6 @@
     "@vue/cli-plugin-router": "4.5.13",
     "@vue/cli-plugin-vuex": "4.5.13",
     "@vue/cli-service": "4.5.13",
-    "@vue/runtime-dom": "^3.2.45",
     "babel-eslint": "^10.1.0",
     "browserslist": "^4.21.5",
     "compression-webpack-plugin": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2844,43 +2844,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/reactivity@npm:3.3.4":
-  version: 3.3.4
-  resolution: "@vue/reactivity@npm:3.3.4"
-  dependencies:
-    "@vue/shared": 3.3.4
-  checksum: 81c3d0c587d23656a57a7a31afb51357274f6512b51baffc67cda183b2361a7e65e646029c26a8bc28587f26b65bba808dcd93cdd3bacab48d2b99d11ad0ec97
-  languageName: node
-  linkType: hard
-
-"@vue/runtime-core@npm:3.3.4":
-  version: 3.3.4
-  resolution: "@vue/runtime-core@npm:3.3.4"
-  dependencies:
-    "@vue/reactivity": 3.3.4
-    "@vue/shared": 3.3.4
-  checksum: d402da51269658cba5d857d65fbe322121160bcb1a6fcf03601d5183705e92505c6e90418f491a331ca3e27628f457a6ca7158b9add25f5b0cf5cf53664b8011
-  languageName: node
-  linkType: hard
-
-"@vue/runtime-dom@npm:^3.2.45":
-  version: 3.3.4
-  resolution: "@vue/runtime-dom@npm:3.3.4"
-  dependencies:
-    "@vue/runtime-core": 3.3.4
-    "@vue/shared": 3.3.4
-    csstype: ^3.1.1
-  checksum: dac9ada7f6128bcccc031fe5c25d00db94ffb7c011fcb70bada22fa4d889ff842eeb139ab9304bcc52cb5ae9030911a52cb3510b691bb190bbe5fab680b4411a
-  languageName: node
-  linkType: hard
-
-"@vue/shared@npm:3.3.4":
-  version: 3.3.4
-  resolution: "@vue/shared@npm:3.3.4"
-  checksum: 12fe53ff816bfa29ea53f89212067a86512c626b8d30149ff28b36705820f6150e1fb4e4e46897ad9eddb1d1cfc02d8941053939910eed69a905f7a5509baabe
-  languageName: node
-  linkType: hard
-
 "@vue/web-component-wrapper@npm:^1.2.0":
   version: 1.3.0
   resolution: "@vue/web-component-wrapper@npm:1.3.0"
@@ -4683,7 +4646,6 @@ __metadata:
     "@vue/cli-plugin-router": 4.5.13
     "@vue/cli-plugin-vuex": 4.5.13
     "@vue/cli-service": 4.5.13
-    "@vue/runtime-dom": ^3.2.45
     "@vueuse/components": ^10.2.0
     "@vueuse/core": ^10.2.0
     apexcharts: ^3.33.2
@@ -5944,7 +5906,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.1.0, csstype@npm:^3.1.1":
+"csstype@npm:^3.1.0":
   version: 3.1.2
   resolution: "csstype@npm:3.1.2"
   checksum: e1a52e6c25c1314d6beef5168da704ab29c5186b877c07d822bd0806717d9a265e8493a2e35ca7e68d0f5d472d43fac1cdce70fd79fd0853dff81f3028d857b5


### PR DESCRIPTION
Vue 2.7 already includes JSX type definitions. You can remove the @vue/runtime-dom dependency from package.json.

vue: /Users/ctrdh/Casaos/CasaOS-UI/main/node_modules/vue/package.json
@vue/runtime-dom: /Users/ctrdh/Casaos/CasaOS-UI/main/node_modules/@vue/runtime-dom/package.json
