### PR TITLE
Add update available notification icon

### DIFF
--- a/main/src/components/Apps/AppCard.vue
+++ b/main/src/components/Apps/AppCard.vue
@@ -130,6 +130,9 @@
 									 webp-fallback=".jpg" @click.native="openApp(item)"></b-image>
 							<!-- Unstable-->
 							<cTooltip v-if="newAppIds.includes(item.name)" class="__position" content="NEW"></cTooltip>
+							<cTooltip v-else-if="hasUpdate" class="__position" modal="is-info" :is-block="true">
+								<b-icon icon="alert-decagram" type="is-warning" style="overflow:unset" :title="$t('New version available!')"></b-icon>
+							</cTooltip>
 						</div>
 
 						<!-- Loading Bar Start -->
@@ -169,6 +172,7 @@ import YAML                    from "yaml";
 import commonI18n, {ice_i18n}  from "@/mixins/base/common-i18n";
 import FileSaver               from 'file-saver';
 import {MIRCO_APP_ACTION_ENUM} from "@/const";
+import apps from "../../service/apps.js";
 
 export default {
 	name: "app-card",
@@ -193,12 +197,35 @@ export default {
 			// Public. Only changes the state of the card, not the state of the button.
 			isSaving: false,
 			isActiveTooltip: false,
+			hasUpdate: false
 		}
 	},
 	props: {
 		item: {
 			type: Object
 		},
+	},
+
+	async mounted() {
+
+		if (!!this.item.store_app_id) {
+			try {
+				const { data: { data: response }} = await apps.getAppComposeV2(this.item.store_app_id);
+
+				const image = response.compose.services[response.store_info.main].image;
+
+				if (!/:latest$/.test(this.item.image) && !/:latest$/.test(image)) {
+					if (this.item.image.trim() !== image.trim()) {
+						this.hasUpdate = true;
+					}
+				} else {
+					// TO DO: logic for handling images with `latest` tag
+				}
+
+			} catch (e) {}
+			
+		}
+
 	},
 
 	computed: {

--- a/main/src/components/basicComponents/tooltip/tooltip.vue
+++ b/main/src/components/basicComponents/tooltip/tooltip.vue
@@ -7,7 +7,10 @@
   * Copyright (c) 2022 by IceWhale, All Rights Reserved.
   -->
 <template>
-	<span :class="rootClass">{{ $t(content) }}</span>
+	<span :class="rootClass">
+		<slot v-if="!!$slots.default"></slot>
+		<template v-else>{{ $t(content) }}</template>
+	</span>
 </template>
 
 <script>

--- a/main/src/service/apps.js
+++ b/main/src/service/apps.js
@@ -34,6 +34,11 @@ const apps = {
 		return api.get(`${PREFIX2}/apps/${id}`);
 	},
 
+	//v2:: Get app compose info from store。
+	getAppComposeV2(id) {
+		return api.get(`${PREFIX2}/apps/${id}/compose`);
+	},
+
 	//v2:: Get app info about config。
 	getAppConfigV2(id) {
 		return api.get(`${PREFIX2}/container/${id}`);


### PR DESCRIPTION
### Description:
Add update available notification icon if the image tag of the corresponding app in the appstore is different from currently installed app. This is to notify the user that a new version is available. 


### Screenshot:
![image](https://github.com/IceWhaleTech/CasaOS-UI/assets/6792172/d6596b77-e45b-4061-9b84-65997e127ed7)
