### PR TITLE
fix #1912: stop action button click event propagation

### DIFF
--- a/main/src/components/filebrowser/components/ActionButton.vue
+++ b/main/src/components/filebrowser/components/ActionButton.vue
@@ -17,7 +17,7 @@
  * @FilePath: /CasaOS-UI/src/components/filebrowser/components/ActionButton.vue
 -->
 <template>
-	<div class="action-btn">
+	<div class="action-btn" @click.stop>
 		<b-dropdown :id="'dr-'+index" ref="dropDown" :close-on-click="false"
 					:position="'is-'+verticalPos+'-'+horizontalPos" animation="fade1"
 					append-to-body aria-role="list" class="file-dropdown"


### PR DESCRIPTION
fix [#1912](https://github.com/IceWhaleTech/CasaOS/issues/1912)

Fixed behaviour:

https://github.com/user-attachments/assets/a61ad493-a372-486a-81ba-cbc4fc530af2

See broken behaviour in the linked GH issue
