### PR TITLE
Fix AppCard dropdown width

### DIFF
--- a/main/src/components/Apps/AppCard.vue
+++ b/main/src/components/Apps/AppCard.vue
@@ -812,7 +812,6 @@ export default {
 
 		.dropdown-content {
 			padding: 4px !important;
-			width: 160px;
 			background: none;
 			background: hsla(0, 0%, 100%, 1);
 			border-radius: 10px;


### PR DESCRIPTION
The default width for the drop down menu is unnecessarily fixed to 160px, which is not enough for some languages.

E.g. in German:
![grafik](https://github.com/user-attachments/assets/b0ec1084-4fff-45f9-aba4-d47e8d1a3f97)

Removing the width enables automatic width which seems to work for all texts. There is still an min-width of 10rem on the parent element as a fallback, for languages with shorter texts.

Fixed:
![grafik](https://github.com/user-attachments/assets/ef42ef4a-9fc3-4078-90ad-3ca344689e94)

