### PR TITLE
fixed the video player not closing on escape

### DIFF
--- a/main/src/components/filebrowser/viewers/VideoPlayer.vue
+++ b/main/src/components/filebrowser/viewers/VideoPlayer.vue
@@ -149,6 +149,11 @@ export default {
 			this.instance.destroy(false);
 		}
 	},
+	methods: {
+		close() {
+			this.$emit("close");
+		}
+	}
 };
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
Close via escape button is not working in the video player

fixes: IceWhaleTech/CasaOS/issues/1990

### Explanation
Added missing close function