### PR TITLE
fix(ImageViewer): Resolve file download issue https://github.com/IceWhaleTech/CasaOS/issues/2210

### DIFF
--- a/src/components/filebrowser/viewers/ImageViewer.vue
+++ b/src/components/filebrowser/viewers/ImageViewer.vue
@@ -164,6 +164,10 @@ export default {
 			this.viewer.show()
 			this.onMouseMove()
 		},
+    download() {
+      this.$refs.dropDown?.toggle()
+      this.downloadFile(this.currentItem)
+    },
 		next() {
 			if (this.currentItemIndex < this.itemList.length - 1) {
 				this.currentItemIndex++


### PR DESCRIPTION
In the `ImageViewer.vue` component, the original download functionality utilized the mixin's download function, which relied on `props.item.path`. This path remains static and isn't updated by the `next` and `prev` functions, leading to incorrect file downloads.

To fix this, the download function in `ImageViewer.vue` has been overridden. The updated implementation now uses `data.currentItem.path`, which dynamically changes with the `next` and `prev` functions, ensuring accurate file downloads.
Close  [#2210](https://github.com/IceWhaleTech/CasaOS/issues/2210)