### PR TITLE
Fix: Can't close 'Found a new drive' message.

### DIFF
--- a/message_bus.build.js
+++ b/message_bus.build.js
@@ -11,9 +11,9 @@ const events = require('./src/events/message_bus.js');
 const fs = require('fs');
 const path = require('path');
 
-const outPath = '../build/sysroot/var/lib/casaos/';
+const outPath = './build/sysroot/var/lib/casaos/';
 const outName = 'ui-message-bus.json';
-const registerShellPath = '../build/sysroot/etc/casaos/start.d/';
+const registerShellPath = './build/sysroot/etc/casaos/start.d/';
 const array = [];
 
 // Parse the event to array

--- a/src/components/noticBlock/noticeBlock.vue
+++ b/src/components/noticBlock/noticeBlock.vue
@@ -120,7 +120,7 @@ export default {
 			this.$messageBus('youshouldknow_cardclose');
 
 			if (this.noticeData.contentType === 'progress') {
-				this.$emit('deleteNotice', this.noticeData, this.noticeType);
+				this.$emit('delete-notice', this.noticeData, this.noticeType);
 				return
 			}
 			let promises = [];
@@ -128,7 +128,7 @@ export default {
 				promises.push(this.$api.users.delLetter(this.noticeData.content[contentKey].messageUUID));
 			}
 			Promise.all(promises).then(() => {
-				this.$emit('deleteNotice', this.noticeData, this.noticeType);
+				this.$emit('delete-notice', this.noticeData, this.noticeType);
 			});
 		},
 		eventBus() {


### PR DESCRIPTION
This PR fixes an event binding issue where `noticeBlock.vue` emitted `deleteNotice` but `CoreService.vue` used `@delete-notice`, which Vue 2 doesn't auto-convert; also corrects the output path in `message_bus.build.js` (was `../build/sysroot/...`), which caused event metadata to be placed outside the expected build directory, leading  to missing frontend event registration after packaging. resolved IceWhaleTech/CasaOS#2069