### PR TITLE
feat: improve date formatting with better i18n support

### DIFF
--- a/src/mixins/mixin.js
+++ b/src/mixins/mixin.js
@@ -396,11 +396,32 @@ export const mixin = {
 		},
 
 		dateFmt: function (value) {
-			if (dayjs().isSame(value, 'year')) {
-				return dayjs(value).format('DD/MM hh:mm')
-			} else {
-				return dayjs(value).format('DD/MM/YYYY hh:mm')
+			const fileDate = new Date(value);
+			const currentDate = new Date();
+			const isSameYear = fileDate.getFullYear() === currentDate.getFullYear();
+			
+			// 获取当前语言环境，默认为浏览器语言
+			const locale = (window.localStorage.getItem('lang') || navigator.language || 'en').replace('_', '-');
+			
+			if (isSameYear) {
+				// 当前年份：只显示月日和时间
+				return new Intl.DateTimeFormat(locale, {
+					month: 'long',
+					day: 'numeric',
+					hour: '2-digit',
+					minute: '2-digit',
+					hour12: false
+				}).format(fileDate)
 			}
+			// 不同年份：显示完整日期和时间
+			return new Intl.DateTimeFormat(locale, {
+				year: 'numeric',
+				month: 'long',
+				day: 'numeric',
+				hour: '2-digit',
+				minute: '2-digit',
+				hour12: false
+			}).format(fileDate)
 		},
 		coverType: function (item) {
 			return item.is_dir ? "folder-cover" : "file-cover"


### PR DESCRIPTION
This PR updates the date/time formatting to be locale-aware, supporting i18n.

Previously, the format was hardcoded (e.g., YYYY-MM-DD), which did not adapt to international users' preferences. Now, it uses the user's local conventions to display dates and times.

