### PR TITLE
Fix: suppress ghost disk events (NaN / NaN undefined) in notifications

### DIFF
--- a/src/components/CoreService.vue
+++ b/src/components/CoreService.vue
@@ -122,6 +122,28 @@ export default {
     this.destroyUIEventBus()
   },
   methods: {
+    _isValidDiskEvent(evt) {
+      let p = {}
+      if (typeof evt?.properties === 'string') {
+        try { p = JSON.parse(evt.properties) } catch (_) { p = {} }
+      } else if (typeof evt?.properties === 'object' && evt.properties !== null) {
+        p = evt.properties
+      }
+
+      const asNum = (v) => {
+        const n = typeof v === 'number' ? v : parseFloat(v)
+        return Number.isFinite(n) ? n : NaN
+      }
+
+      const size = asNum(p.size)
+      if (!size || !Number.isFinite(size) || size <= 0) return false
+
+      const path = p['local-storage:path'] || p.path || ''
+      const mnt  = p.mount_point || ''
+      if (typeof path === 'string' && path.startsWith('/dev/loop') && !mnt) return false
+
+      return true
+    }
     createWS(domain) {
       let socket
       // reference:
@@ -217,6 +239,11 @@ export default {
       }
 
       const operateType = eventJson.name.split(':')[2]
+      if (eventJson.name === 'local-storage:disk:added' && !this._isValidDiskEvent(eventJson)) {
+        // delete letter which is invalid disk event!
+        this.$api.users.delLetter(eventJson.uuid)
+        return
+      }
       const entityUUID = eventJson.properties.serial || eventJson.properties['local-storage:uuid']
       switch (eventType) {
         case 'usb':


### PR DESCRIPTION
This prevents invalid “Found a new drive” notifications caused by leftover loop devices or zero-size/invalid disks.

Changes:

Added _isValidDiskEvent helper in CoreService.vue to validate incoming local-storage:disk:added events.

Skip events with:

size missing, "NaN", or 0.

/dev/loop* devices that have no mount point.

Invalid events are cleaned from the user DB via this.$api.users.delLetter(eventJson.uuid) so they don’t persist across reloads.

Why:
Several users reported seeing random “Found a new drive NaN / NaN undefined” popups in the UI. These come from orphaned loop devices or misdetected volumes. This patch hides those junk events while preserving normal drive management (real disks and mounted loops still work as expected).

Impact:

End users no longer see phantom drive popups.

No backend or DB schema changes.

Does not unmount, delete, or modify real drives — only filters junk notifications.