### PR TITLE
Improve UI app launching with qBittorrent iframe exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@fontsource/roboto": "^5.0.5",
     "@icewhale/casaos-appmanagement-openapi": "latest",
     "@icewhale/casaos-openapi": "latest",
-    "@icewhale/icewhale-files-openapi": "latest",
     "@kangc/v-md-editor": "^1.7.11",
     "@mdi/font": "^6.9.96",
     "@tiptap/core": "^2.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,10 @@ importers:
         version: 5.1.0
       '@icewhale/casaos-appmanagement-openapi':
         specifier: latest
-        version: 0.4.10-alpha2
+        version: 0.4.17-alpha1
       '@icewhale/casaos-openapi':
         specifier: latest
-        version: 0.4.13-2adb795
-      '@icewhale/icewhale-files-openapi':
-        specifier: latest
-        version: 1.3.0-alpha133
+        version: 0.4.17-alpha1-a6ff39e
       '@kangc/v-md-editor':
         specifier: ^1.7.11
         version: 1.7.12(vue-template-compiler@2.7.16)(vue@2.7.16)
@@ -299,19 +296,19 @@ importers:
         version: 4.3.0(@vue/compiler-sfc@3.5.13)(prettier@3.4.1)
       '@vue/cli-plugin-babel':
         specifier: 5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))(core-js@3.39.0)(vue@2.7.16)(webpack-cli@5.1.4)
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))(core-js@3.39.0)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       '@vue/cli-plugin-eslint':
         specifier: 5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))(eslint@8.57.1)(webpack-cli@5.1.4)
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))(eslint@8.57.1)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       '@vue/cli-plugin-router':
         specifier: 5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))
       '@vue/cli-plugin-vuex':
         specifier: 5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))
       '@vue/cli-service':
         specifier: 5.0.8
-        version: 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3)
+        version: 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3)
       babel-eslint:
         specifier: ^10.1.0
         version: 10.1.0(eslint@8.57.1)
@@ -320,10 +317,10 @@ importers:
         version: 4.24.2
       compression-webpack-plugin:
         specifier: 5.0.2
-        version: 5.0.2(webpack@5.96.1)
+        version: 5.0.2(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       css-minimizer-webpack-plugin:
         specifier: ^7.0.0
-        version: 7.0.0(webpack@5.96.1)
+        version: 7.0.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -350,7 +347,7 @@ importers:
         version: 1.8.2
       node-polyfill-webpack-plugin:
         specifier: ^4.0.0
-        version: 4.0.0(webpack@5.96.1)
+        version: 4.0.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       patch-package:
         specifier: ^7.0.2
         version: 7.0.2
@@ -362,7 +359,7 @@ importers:
         version: 16.1.0(postcss@8.4.49)
       postcss-loader:
         specifier: ^4.3.0
-        version: 4.3.0(postcss@8.4.49)(webpack@5.96.1)
+        version: 4.3.0(postcss@8.4.49)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       postinstall-postinstall:
         specifier: ^2.1.0
         version: 2.1.0
@@ -380,10 +377,10 @@ importers:
         version: 1.44.0
       sass-loader:
         specifier: 10.4.1
-        version: 10.4.1(sass@1.44.0)(webpack@5.96.1)
+        version: 10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       style-resources-loader:
         specifier: ^1.5.0
-        version: 1.5.0(webpack@5.96.1)
+        version: 1.5.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       swiper:
         specifier: ^5.4.5
         version: 5.4.5
@@ -392,7 +389,7 @@ importers:
         version: 3.4.15
       terser-webpack-plugin:
         specifier: 5.3.10
-        version: 5.3.10(webpack@5.96.1)
+        version: 5.3.10(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -1130,14 +1127,11 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@icewhale/casaos-appmanagement-openapi@0.4.10-alpha2':
-    resolution: {integrity: sha512-6NrM0nb1YyBsAIOOjTY1bqBALDHdkSQ5NLIM4Jt8JuhNCrlmpBLr1R5k2b8de+q6BRIEhTUQwWfaIxu5yrKcEA==}
+  '@icewhale/casaos-appmanagement-openapi@0.4.17-alpha1':
+    resolution: {integrity: sha512-j2P9820B5DGGIyno/p0l65jeOqoVsmiKKCnGOUxoybuPunSgeYtYyotILnmsE+vgSLi+JQibQ+yvtBW1mrI7VQ==}
 
-  '@icewhale/casaos-openapi@0.4.13-2adb795':
-    resolution: {integrity: sha512-abitonoBcPCR7TCMJh69OMNScHuiS5DCNvyQo/cpEJ00ceThazbcHLUtiCRxAA4fUy++RlWqmbHw++BE5Aj5EA==}
-
-  '@icewhale/icewhale-files-openapi@1.3.0-alpha133':
-    resolution: {integrity: sha512-EQz1nG4HuIKyi98JfoZ03UpM7JRbwYByf7UeWa0fknNWNMQ2mF4hUHcfQ73YfkhQ51oL/yk9l9Qyvr56LAHh+w==}
+  '@icewhale/casaos-openapi@0.4.17-alpha1-a6ff39e':
+    resolution: {integrity: sha512-PdnCNgTAuC+EXhPSBP9fLToBI7bt+qO529Fn4O8JOc6m4lipHp+dzoR8VdMXCe7rZv8MYFiEviWqeTTmJcOgRg==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1708,6 +1702,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/eslint-plugin@1.1.14':
     resolution: {integrity: sha512-ej0cT5rUt7uvwxuu7Qxkm7fI+eaOq8vD34qGpuRoXCdvOybOlE5GDqtgvVCYbxLANkcRJfm5VDU1TnJmQRHi9g==}
@@ -2649,8 +2644,8 @@ packages:
     resolution: {integrity: sha512-kPIEgkU2TRT1t4ZrBPUmmRr7RGA0E5JYx0rAgpWBRWNjZRDr2FV/8ne8S8iLp7oaqEX1ubDqZPEQvHaDM9d7cg==}
     hasBin: true
 
-  composeverter@1.7.2:
-    resolution: {integrity: sha512-gRSCkSU8wJQvmTHQ23wBd2gCdUsns95k3lL7YszZBu5EyA3eac46mI7nVgvk1pZTM0mOmj/E5yurtdYkuVNZRA==}
+  composeverter@1.7.5:
+    resolution: {integrity: sha512-XUPZdktweMFFMk7oLFOOFZeuZ4U0jY/MpisUmRkHImybn9PvixceiKGVMMwSL19P9Mr5Ty1A7bmG2lFWn5UWTA==}
 
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -3795,6 +3790,7 @@ packages:
   eslint-plugin-markdown@5.1.0:
     resolution: {integrity: sha512-SJeyKko1K6GwI0AN6xeCDToXDkfKZfXcexA6B+O2Wr2btUS9GrC+YgwSyVli5DJnctUHjFXcQ2cqTaAmVoLi2A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: Please use @eslint/markdown instead
     peerDependencies:
       eslint: '>=8'
 
@@ -4253,11 +4249,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -4578,6 +4575,7 @@ packages:
 
   intersection-observer@0.12.2:
     resolution: {integrity: sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==}
+    deprecated: The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -7173,6 +7171,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.10:
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
@@ -7494,6 +7493,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v-animate-css@0.0.6:
@@ -7620,6 +7620,7 @@ packages:
 
   vue-i18n@8.28.2:
     resolution: {integrity: sha512-C5GZjs1tYlAqjwymaaCPDjCyGo10ajUphiwA922jKt9n7KPpqR7oM1PCwYzhB/E7+nT3wfdG3oRre5raIT1rKA==}
+    deprecated: v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html
     peerDependencies:
       vue: ^2
 
@@ -7847,6 +7848,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -8961,19 +8963,13 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@icewhale/casaos-appmanagement-openapi@0.4.10-alpha2':
+  '@icewhale/casaos-appmanagement-openapi@0.4.17-alpha1':
     dependencies:
       axios: 1.7.8
     transitivePeerDependencies:
       - debug
 
-  '@icewhale/casaos-openapi@0.4.13-2adb795':
-    dependencies:
-      axios: 1.7.8
-    transitivePeerDependencies:
-      - debug
-
-  '@icewhale/icewhale-files-openapi@1.3.0-alpha133':
+  '@icewhale/casaos-openapi@0.4.17-alpha1-a6ff39e':
     dependencies:
       axios: 1.7.8
     transitivePeerDependencies:
@@ -9162,13 +9158,13 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 1.8.6
 
-  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.96.1)':
+  '@soda/friendly-errors-webpack-plugin@1.8.1(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))':
     dependencies:
       chalk: 3.0.0
       error-stack-parser: 2.1.4
       string-width: 4.2.3
       strip-ansi: 6.0.1
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   '@soda/get-current-script@1.0.2': {}
 
@@ -9796,15 +9792,15 @@ snapshots:
 
   '@vue/cli-overlay@5.0.8': {}
 
-  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))(core-js@3.39.0)(vue@2.7.16)(webpack-cli@5.1.4)':
+  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))(core-js@3.39.0)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))':
     dependencies:
       '@babel/core': 7.26.0
       '@vue/babel-preset-app': 5.0.8(@babel/core@7.26.0)(core-js@3.39.0)(vue@2.7.16)
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8
-      babel-loader: 8.4.1(@babel/core@7.26.0)(webpack@5.96.1)
-      thread-loader: 3.0.4(webpack@5.96.1)
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      babel-loader: 8.4.1(@babel/core@7.26.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
+      thread-loader: 3.0.4(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
     transitivePeerDependencies:
       - '@swc/core'
       - core-js
@@ -9815,14 +9811,14 @@ snapshots:
       - vue
       - webpack-cli
 
-  '@vue/cli-plugin-eslint@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))(eslint@8.57.1)(webpack-cli@5.1.4)':
+  '@vue/cli-plugin-eslint@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))(eslint@8.57.1)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8
       eslint: 8.57.1
-      eslint-webpack-plugin: 3.2.0(eslint@8.57.1)(webpack@5.96.1)
+      eslint-webpack-plugin: 3.2.0(eslint@8.57.1)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       globby: 11.1.0
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       yorkie: 2.0.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -9831,29 +9827,29 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))':
+  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))':
+  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3)
 
-  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3)':
+  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3)':
     dependencies:
       '@babel/helper-compilation-targets': 7.25.9
-      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.96.1)
+      '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.5
       '@vue/cli-overlay': 5.0.8
-      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))
-      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4)(webpack-sources@3.2.3))
+      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))
+      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.13)(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(underscore@1.13.7)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-sources@3.2.3))
       '@vue/cli-shared-utils': 5.0.8
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(lodash@4.17.21)(underscore@1.13.7)
-      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.5.13)(css-loader@6.11.0(webpack@5.96.1))(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(underscore@1.13.7)(vue-template-compiler@2.7.16)(webpack@5.96.1)
+      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.5.13)(css-loader@6.11.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(underscore@1.13.7)(vue-template-compiler@2.7.16)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       '@vue/web-component-wrapper': 1.3.0
       acorn: 8.14.0
       acorn-walk: 8.3.4
@@ -9864,9 +9860,9 @@ snapshots:
       cli-highlight: 2.1.11
       clipboardy: 2.3.0
       cliui: 7.0.4
-      copy-webpack-plugin: 9.1.0(webpack@5.96.1)
-      css-loader: 6.11.0(webpack@5.96.1)
-      css-minimizer-webpack-plugin: 3.4.1(webpack@5.96.1)
+      copy-webpack-plugin: 9.1.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
+      css-loader: 6.11.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
+      css-minimizer-webpack-plugin: 3.4.1(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       cssnano: 5.1.15(postcss@8.4.49)
       debug: 4.3.7
       default-gateway: 6.0.3
@@ -9875,32 +9871,32 @@ snapshots:
       fs-extra: 9.1.0
       globby: 11.1.0
       hash-sum: 2.0.0
-      html-webpack-plugin: 5.6.3(webpack@5.96.1)
+      html-webpack-plugin: 5.6.3(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       is-file-esm: 1.0.0
       launch-editor-middleware: 2.9.1
       lodash.defaultsdeep: 4.6.1
       lodash.mapvalues: 4.6.0
-      mini-css-extract-plugin: 2.9.2(webpack@5.96.1)
+      mini-css-extract-plugin: 2.9.2(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       minimist: 1.2.8
       module-alias: 2.2.3
       portfinder: 1.0.32
       postcss: 8.4.49
-      postcss-loader: 6.2.1(postcss@8.4.49)(webpack@5.96.1)
-      progress-webpack-plugin: 1.0.16(webpack@5.96.1)
+      postcss-loader: 6.2.1(postcss@8.4.49)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
+      progress-webpack-plugin: 1.0.16(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       ssri: 8.0.1
-      terser-webpack-plugin: 5.3.10(webpack@5.96.1)
-      thread-loader: 3.0.4(webpack@5.96.1)
-      vue-loader: 17.4.2(@vue/compiler-sfc@3.5.13)(vue@2.7.16)(webpack@5.96.1)
+      terser-webpack-plugin: 5.3.10(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
+      thread-loader: 3.0.4(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
+      vue-loader: 17.4.2(@vue/compiler-sfc@3.5.13)(vue@2.7.16)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       vue-style-loader: 4.1.3
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       webpack-bundle-analyzer: 4.10.2
       webpack-chain: 6.5.1
-      webpack-dev-server: 4.15.2(debug@4.3.7)(webpack-cli@5.1.4)(webpack@5.96.1)
+      webpack-dev-server: 4.15.2(debug@4.3.7)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       webpack-merge: 5.10.0
       webpack-virtual-modules: 0.4.6
       whatwg-fetch: 3.6.20
     optionalDependencies:
-      sass-loader: 10.4.1(sass@1.44.0)(webpack@5.96.1)
+      sass-loader: 10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       vue-template-compiler: 2.7.16
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -10229,19 +10225,19 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.96.1)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))':
     dependencies:
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       webpack-cli: 5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.96.1)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))':
     dependencies:
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       webpack-cli: 5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.1.0)(webpack@5.96.1)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-dev-server@5.1.0(webpack-cli@5.1.4)(webpack@5.96.1))(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))':
     dependencies:
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       webpack-cli: 5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)
     optionalDependencies:
       webpack-dev-server: 5.1.0(webpack-cli@5.1.4)(webpack@5.96.1)
@@ -10494,14 +10490,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@8.4.1(@babel/core@7.26.0)(webpack@5.96.1):
+  babel-loader@8.4.1(@babel/core@7.26.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       '@babel/core': 7.26.0
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -10954,31 +10950,31 @@ snapshots:
 
   composerize@1.6.12:
     dependencies:
-      composeverter: 1.7.2
+      composeverter: 1.7.5
       core-js: 2.6.12
       deepmerge: 2.2.1
       invariant: 2.2.4
       yaml: 1.10.2
       yargs-parser: 13.1.2
 
-  composeverter@1.7.2:
+  composeverter@1.7.5:
     dependencies:
       ajv: 8.17.1
       ajv-errors: 3.0.0(ajv@8.17.1)
       core-js: 2.6.12
-      yaml: 1.10.2
+      yaml: 2.6.1
 
   compressible@2.0.18:
     dependencies:
       mime-db: 1.53.0
 
-  compression-webpack-plugin@5.0.2(webpack@5.96.1):
+  compression-webpack-plugin@5.0.2(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       cacache: 15.3.0
       find-cache-dir: 3.3.2
       schema-utils: 2.7.1
       serialize-javascript: 4.0.0
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - bluebird
@@ -11035,7 +11031,7 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
-  copy-webpack-plugin@9.1.0(webpack@5.96.1):
+  copy-webpack-plugin@9.1.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -11043,7 +11039,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   core-js-compat@3.39.0:
     dependencies:
@@ -11130,7 +11126,7 @@ snapshots:
     dependencies:
       postcss: 8.4.49
 
-  css-loader@6.11.0(webpack@5.96.1):
+  css-loader@6.11.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.49)
       postcss: 8.4.49
@@ -11141,9 +11137,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
-  css-minimizer-webpack-plugin@3.4.1(webpack@5.96.1):
+  css-minimizer-webpack-plugin@3.4.1(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       cssnano: 5.1.15(postcss@8.4.49)
       jest-worker: 27.5.1
@@ -11151,9 +11147,9 @@ snapshots:
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
       source-map: 0.6.1
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
-  css-minimizer-webpack-plugin@7.0.0(webpack@5.96.1):
+  css-minimizer-webpack-plugin@7.0.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       cssnano: 7.0.6(postcss@8.4.49)
@@ -11161,7 +11157,7 @@ snapshots:
       postcss: 8.4.49
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   css-select@4.3.0:
     dependencies:
@@ -12315,7 +12311,7 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint-webpack-plugin@3.2.0(eslint@8.57.1)(webpack@5.96.1):
+  eslint-webpack-plugin@3.2.0(eslint@8.57.1)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       '@types/eslint': 8.56.12
       eslint: 8.57.1
@@ -12323,7 +12319,7 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       schema-utils: 4.2.0
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   eslint@8.57.1:
     dependencies:
@@ -12942,7 +12938,7 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.96.1):
+  html-webpack-plugin@5.6.3(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -12950,7 +12946,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   htmlhint@1.1.4:
     dependencies:
@@ -13893,11 +13889,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.96.1):
+  mini-css-extract-plugin@2.9.2(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   minimalistic-assert@1.0.1: {}
 
@@ -14050,7 +14046,7 @@ snapshots:
 
   node-forge@1.3.1: {}
 
-  node-polyfill-webpack-plugin@4.0.0(webpack@5.96.1):
+  node-polyfill-webpack-plugin@4.0.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -14076,7 +14072,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   node-releases@2.0.18: {}
 
@@ -14520,7 +14516,7 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.49
 
-  postcss-loader@4.3.0(postcss@8.4.49)(webpack@5.96.1):
+  postcss-loader@4.3.0(postcss@8.4.49)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
@@ -14528,15 +14524,15 @@ snapshots:
       postcss: 8.4.49
       schema-utils: 3.3.0
       semver: 7.6.3
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
-  postcss-loader@6.2.1(postcss@8.4.49)(webpack@5.96.1):
+  postcss-loader@6.2.1(postcss@8.4.49)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       postcss: 8.4.49
       semver: 7.6.3
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   postcss-merge-longhand@5.1.7(postcss@8.4.49):
     dependencies:
@@ -14853,12 +14849,12 @@ snapshots:
 
   process@0.11.10: {}
 
-  progress-webpack-plugin@1.0.16(webpack@5.96.1):
+  progress-webpack-plugin@1.0.16(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       chalk: 2.4.2
       figures: 2.0.0
       log-update: 2.3.0
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   promise-inflight@1.0.1: {}
 
@@ -15271,14 +15267,14 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1):
+  sass-loader@10.4.1(sass@1.44.0)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       klona: 2.0.6
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
       semver: 7.6.3
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
     optionalDependencies:
       sass: 1.44.0
 
@@ -15715,13 +15711,13 @@ snapshots:
       '@tokenizer/token': 0.3.0
       peek-readable: 4.1.0
 
-  style-resources-loader@1.5.0(webpack@5.96.1):
+  style-resources-loader@1.5.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       glob: 7.2.3
       loader-utils: 2.0.4
       schema-utils: 2.7.1
       tslib: 2.8.1
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   stylehacks@5.1.1(postcss@8.4.49):
     dependencies:
@@ -15837,14 +15833,14 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  terser-webpack-plugin@5.3.10(webpack@5.96.1):
+  terser-webpack-plugin@5.3.10(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   terser@5.36.0:
     dependencies:
@@ -15867,14 +15863,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  thread-loader@3.0.4(webpack@5.96.1):
+  thread-loader@3.0.4(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.0
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
   thunky@1.1.0: {}
 
@@ -16270,15 +16266,15 @@ snapshots:
     dependencies:
       vue: 2.7.16
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.5.13)(css-loader@6.11.0(webpack@5.96.1))(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(underscore@1.13.7)(vue-template-compiler@2.7.16)(webpack@5.96.1):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.5.13)(css-loader@6.11.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))))(ejs@3.1.10)(lodash@4.17.21)(prettier@3.4.1)(underscore@1.13.7)(vue-template-compiler@2.7.16)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(lodash@4.17.21)(underscore@1.13.7)
-      css-loader: 6.11.0(webpack@5.96.1)
+      css-loader: 6.11.0(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.13
       prettier: 3.4.1
@@ -16338,12 +16334,12 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(@vue/compiler-sfc@3.5.13)(vue@2.7.16)(webpack@5.96.1):
+  vue-loader@17.4.2(@vue/compiler-sfc@3.5.13)(vue@2.7.16)(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.2
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.13
       vue: 2.7.16
@@ -16470,9 +16466,9 @@ snapshots:
   webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.96.1)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.96.1)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.1.0)(webpack@5.96.1)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack-dev-server@5.1.0(webpack-cli@5.1.4)(webpack@5.96.1))(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -16481,21 +16477,21 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-dev-server: 5.1.0(webpack-cli@5.1.4)(webpack@5.96.1)
 
-  webpack-dev-middleware@5.3.4(webpack@5.96.1):
+  webpack-dev-middleware@5.3.4(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
-  webpack-dev-middleware@7.4.2(webpack@5.96.1):
+  webpack-dev-middleware@7.4.2(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       colorette: 2.0.20
       memfs: 4.14.0
@@ -16504,9 +16500,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
 
-  webpack-dev-server@4.15.2(debug@4.3.7)(webpack-cli@5.1.4)(webpack@5.96.1):
+  webpack-dev-server@4.15.2(debug@4.3.7)(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -16536,10 +16532,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.96.1)
+      webpack-dev-middleware: 5.3.4(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       ws: 8.18.0
     optionalDependencies:
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       webpack-cli: 5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)
     transitivePeerDependencies:
       - bufferutil
@@ -16575,10 +16571,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.2(webpack@5.96.1)
+      webpack-dev-middleware: 7.4.2(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       ws: 8.18.0
     optionalDependencies:
-      webpack: 5.96.1(webpack-cli@5.1.4)
+      webpack: 5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1))
       webpack-cli: 5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)
     transitivePeerDependencies:
       - bufferutil
@@ -16601,7 +16597,7 @@ snapshots:
 
   webpack-virtual-modules@0.4.6: {}
 
-  webpack@5.96.1(webpack-cli@5.1.4):
+  webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -16623,7 +16619,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.96.1)
+      terser-webpack-plugin: 5.3.10(webpack@5.96.1(webpack-cli@5.1.4(webpack-dev-server@5.1.0)(webpack@5.96.1)))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,6 +23,17 @@
 		<router-view/>
 		<!-- Router View End -->
 
+		<app-launcher-check
+			v-if="appLauncher"
+			:app-detail="appLauncher"
+		/>
+		<app-iframe
+			v-if="appIframe"
+			:app-name="appIframe.name"
+			:url="appIframe.url"
+			@close="closeAppFrame"
+		/>
+
 	</div>
 </template>
 
@@ -30,7 +41,10 @@
 import BrandBar      from './components/BrandBar.vue'
 import ContactBar    from './components/ContactBar.vue'
 import CasaWallpaper from './components/wallpaper/CasaWallpaper.vue'
+import AppIframe from './components/Apps/AppIframe.vue'
+import AppLauncherCheck from './views/AppLauncherCheck.vue'
 import {mixin}       from './mixins/mixin';
+import events from '@/events/events'
 
 const customIconConfig = {
 	customIconPacks: {
@@ -67,7 +81,9 @@ export default {
 	components: {
 		BrandBar,
 		ContactBar,
-		CasaWallpaper
+		CasaWallpaper,
+		AppIframe,
+		AppLauncherCheck,
 	},
 	mixins: [mixin],
 	data() {
@@ -90,7 +106,9 @@ export default {
 				classes: "fadeInRight",
 				duration: 700
 			},
-			"vh": "0px"
+			"vh": "0px",
+			appIframe: null,
+			appLauncher: null,
 		}
 	},
 
@@ -121,8 +139,29 @@ _____             _____ _____
 		this.onWindowResize();
 		let vh = window.innerHeight * 0.01;
 		this["vh"] = `${vh}px`;
+		this.$EventBus.$on(events.OPEN_APP_IFRAME, this.openAppIframe)
+		this.$EventBus.$on(events.OPEN_APP_LAUNCHER, this.openAppLauncher)
+		this.$EventBus.$on(events.CLOSE_APP_IFRAME, this.closeAppFrame)
+	},
+	beforeDestroy() {
+		window.removeEventListener('resize', this.onWindowResize);
+		this.$EventBus.$off(events.OPEN_APP_IFRAME, this.openAppIframe)
+		this.$EventBus.$off(events.OPEN_APP_LAUNCHER, this.openAppLauncher)
+		this.$EventBus.$off(events.CLOSE_APP_IFRAME, this.closeAppFrame)
 	},
 	methods: {
+		openAppIframe(appData) {
+			this.appLauncher = null
+			this.appIframe = appData
+		},
+		openAppLauncher(appData) {
+			this.appIframe = null
+			this.appLauncher = appData
+		},
+		closeAppFrame() {
+			this.appIframe = null
+			this.appLauncher = null
+		},
 		/**
 		 * @description: Get and Set default language
 		 * @return {*} void

--- a/src/assets/lang/en_US.json
+++ b/src/assets/lang/en_US.json
@@ -203,6 +203,8 @@
   "New Folder": "New folder",
   "New File": "New file",
   "Change View": "Change view",
+  "Show hidden files": "Show hidden files",
+  "Hide hidden files": "Hide hidden files",
   "Upload to": "Upload to",
   "Uploading": "Uploading",
   "uploading": "Uploading",

--- a/src/components/Apps/AppIframe.vue
+++ b/src/components/Apps/AppIframe.vue
@@ -5,29 +5,33 @@
     role="dialog"
     :aria-label="appName"
   >
-    <header class="app-iframe-header is-flex is-align-items-center">
-      <h1 class="app-iframe-title is-flex-grow-1 mb-0">
-        {{ appName }}
-      </h1>
-      <button
-        class="app-iframe-close"
-        type="button"
-        :aria-label="$t('Close')"
-        :title="$t('Close')"
-        @click="$emit('close')"
-      >
-        <b-icon custom-size="casa-24px" icon="close-outline" pack="casa" />
-      </button>
-    </header>
-    <div class="app-iframe-content">
-      <iframe
-        :src="url"
-        :title="appName"
-        allow="autoplay; fullscreen"
-        allowfullscreen
-        class="app-iframe"
-      />
-    </div>
+    <transition name="c-zoom-in" appear>
+      <div class="app-iframe-dialog">
+        <header class="app-iframe-header is-flex is-align-items-center">
+          <h1 class="app-iframe-title is-flex-grow-1 mb-0">
+            {{ appName }}
+          </h1>
+          <button
+            class="app-iframe-close"
+            type="button"
+            :aria-label="$t('Close')"
+            :title="$t('Close')"
+            @click="$emit('close')"
+          >
+            <b-icon custom-size="casa-24px" icon="close-outline" pack="casa" />
+          </button>
+        </header>
+        <div class="app-iframe-content">
+          <iframe
+            :src="url"
+            :title="appName"
+            allow="autoplay; fullscreen"
+            allowfullscreen
+            class="app-iframe"
+          />
+        </div>
+      </div>
+    </transition>
   </section>
 </template>
 
@@ -53,16 +57,33 @@ export default {
   inset: 0;
   z-index: 1000;
   display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  overflow: auto;
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.app-iframe-dialog {
+  display: flex;
   flex-direction: column;
+  width: 90vw;
+  height: 90vh;
+  max-width: 81rem;
+  min-height: 0;
+  overflow: hidden;
   background: #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.25);
 }
 
 .app-iframe-header {
-  flex: 0 0 3.25rem;
-  min-height: 3.25rem;
-  padding: 0 1rem 0 1.25rem;
-  color: #fff;
-  background: #1e1e1e;
+  flex: 0 0 3.5rem;
+  min-height: 3.5rem;
+  padding: 1.25rem 1.25rem 0.5rem 1.5rem;
+  color: #363636;
+  background-color: hsla(208, 16%, 94%, 1);
+  border-bottom: 1px solid rgb(228, 233, 237);
 }
 
 .app-iframe-title {
@@ -92,11 +113,11 @@ export default {
 
 .app-iframe-close:hover,
 .app-iframe-close:focus-visible {
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.08);
 }
 
 .app-iframe-close:focus {
-  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline: 2px solid rgba(54, 54, 54, 0.45);
   outline-offset: 2px;
 }
 
@@ -111,5 +132,17 @@ export default {
   width: 100%;
   height: 100%;
   border: 0;
+}
+
+@media screen and (max-width: 768px) {
+  .app-iframe-overlay {
+    padding: 0;
+  }
+
+  .app-iframe-dialog {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
 }
 </style>

--- a/src/components/Apps/AppIframe.vue
+++ b/src/components/Apps/AppIframe.vue
@@ -1,0 +1,115 @@
+<template>
+  <section
+    aria-modal="true"
+    class="app-iframe-overlay"
+    role="dialog"
+    :aria-label="appName"
+  >
+    <header class="app-iframe-header is-flex is-align-items-center">
+      <h1 class="app-iframe-title is-flex-grow-1 mb-0">
+        {{ appName }}
+      </h1>
+      <button
+        class="app-iframe-close"
+        type="button"
+        :aria-label="$t('Close')"
+        :title="$t('Close')"
+        @click="$emit('close')"
+      >
+        <b-icon custom-size="casa-24px" icon="close-outline" pack="casa" />
+      </button>
+    </header>
+    <div class="app-iframe-content">
+      <iframe
+        :src="url"
+        :title="appName"
+        allow="autoplay; fullscreen"
+        allowfullscreen
+        class="app-iframe"
+      />
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'AppIframe',
+  props: {
+    appName: {
+      type: String,
+      default: '',
+    },
+    url: {
+      type: String,
+      required: true,
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.app-iframe-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+}
+
+.app-iframe-header {
+  flex: 0 0 3.25rem;
+  min-height: 3.25rem;
+  padding: 0 1rem 0 1.25rem;
+  color: #fff;
+  background: #1e1e1e;
+}
+
+.app-iframe-title {
+  overflow: hidden;
+  color: inherit;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-iframe-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 2.25rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: 0.25rem;
+}
+
+.app-iframe-close:hover,
+.app-iframe-close:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.app-iframe-close:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
+}
+
+.app-iframe-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  background: #fff;
+}
+
+.app-iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+</style>

--- a/src/components/filebrowser/FilePanel.vue
+++ b/src/components/filebrowser/FilePanel.vue
@@ -118,7 +118,7 @@
 								<!-- Header End -->
 
 								<!-- Tool Bar Start -->
-								<div v-if="listData.length > 0" class="tool-bar is-flex mb-2 mt-2 is-flex-shrink-0">
+								<div v-if="allListData.length > 0" class="tool-bar is-flex mb-2 mt-2 is-flex-shrink-0">
 									<div class="is-flex-grow-1 has-text-left is-flex is-align-items-center">
 										<b-field class="ml-1 is-flex is-size-14px mb-0" expanded >
 											<b-checkbox v-model="isSelectAll" :class="selectState" size="is-small"
@@ -132,6 +132,14 @@
 										</b-field>
 									</div>
 									<div class="view-btns is-flex-shrink-0">
+										<b-tooltip :label="showHiddenFilesLabel" position="is-left" type="is-dark">
+											<p :aria-label="showHiddenFilesLabel" :aria-pressed="showHiddenFiles"
+												class="is-clickable none-line-height mr-3" role="button" tabindex="0"
+												@keydown.enter.prevent="toggleHiddenFiles" @keydown.space.prevent="toggleHiddenFiles"
+												@click="toggleHiddenFiles">
+												<b-icon :icon="hiddenFilesIcon" pack="casa"></b-icon>
+											</p>
+										</b-tooltip>
 										<b-tooltip :label="$t('Change View')" position="is-left" type="is-dark">
 											<p class="is-clickable none-line-height" role="button" @click="changeView">
 												<b-icon :icon="viewIcon"></b-icon>
@@ -229,6 +237,7 @@ import dropRight from "lodash/dropRight";
 import isEqual from "lodash/isEqual";
 
 import { mixin } from "@/mixins/mixin";
+import { filterHiddenFiles } from "@/mixins/file_utils";
 import VueBreakpointMixin from "vue-breakpoint-mixin";
 import events from "@/events/events";
 
@@ -264,6 +273,8 @@ import MergeStorages from "@/components/Storage/MergeStorages.vue";
 
 // Drop
 import DropEntryButton from "./drop/DropEntryButton.vue";
+
+const SHOW_HIDDEN_FILES_STORAGE_KEY = "casaos-filebrowser-show-hidden-files";
 
 export default {
 	name: "file-panel",
@@ -320,6 +331,8 @@ export default {
 			currentPath: "",
 			currentPathName: "",
 			isViewGird: true,
+			showHiddenFiles: localStorage.getItem(SHOW_HIDDEN_FILES_STORAGE_KEY) === "true",
+			allListData: [],
 			listData: [],
 			selectedArray: [],
 			file: null,
@@ -381,6 +394,12 @@ export default {
 			return this.$store.state.isViewGird
 				? "view-grid-outline"
 				: "format-list-bulleted";
+		},
+		hiddenFilesIcon() {
+			return this.showHiddenFiles ? "eye-off" : "eye";
+		},
+		showHiddenFilesLabel() {
+			return this.$t(this.showHiddenFiles ? "Hide hidden files" : "Show hidden files");
 		},
 		listView() {
 			return this.$store.state.isViewGird ? "gird-view" : "list-view";
@@ -566,7 +585,7 @@ export default {
 						this.isLoading = false;
 						this.currentPathName = path.split("/").pop();
 						const fileList = res.data.data.content;
-						const newFileList = fileList.map((item) => {
+						this.allListData = fileList.map((item) => {
 							return {
 								date: item.date,
 								isSelected: false,
@@ -578,11 +597,7 @@ export default {
 								extensions: item.extensions,
 							};
 						});
-						// filter hidden files
-						const filterList = newFileList.filter((item) => {
-							return !item.name.startsWith(".");
-						});
-						this.listData = orderBy(filterList, ["is_dir"], ["desc"]);
+						this.updateVisibleList();
 						this.handelListChange(this.listData);
 						this.errorMsg = "";
 						this.isEmpty = true;
@@ -591,6 +606,7 @@ export default {
 				.catch((error) => {
 					this.isLoading = false;
 					this.isEmpty = false;
+					this.allListData = [];
 					this.listData = [];
 					this.errorMsg = error.response.data.data;
 					this.handelListChange(this.listData);
@@ -615,6 +631,44 @@ export default {
 		changeView() {
 			this.isViewGird = !this.$store.state.isViewGird;
 			this.$store.commit("SET_IS_VIEW_GRID", this.isViewGird);
+		},
+
+		/**
+		 * @description: Apply the hidden-file preference to the current folder.
+		 * @return {*}
+		 */
+		updateVisibleList() {
+			const visibleList = filterHiddenFiles(this.allListData, this.showHiddenFiles);
+			this.listData = orderBy(visibleList, ["is_dir"], ["desc"]);
+		},
+
+		/**
+		 * @description: Reset selection state after changing the visible list.
+		 * @return {*}
+		 */
+		clearSelection() {
+			this.allListData.forEach((item) => {
+				item.isSelected = false;
+			});
+			this.selectedArray = [];
+			this.selectState = "none";
+			this.isSelectAll = false;
+			this.isToolbarShow = false;
+			if (this.$refs.listview) {
+				this.$refs.listview.selectList = [];
+			}
+		},
+
+		/**
+		 * @description: Toggle visibility of dot-prefixed files and folders.
+		 * @return {*}
+		 */
+		toggleHiddenFiles() {
+			this.showHiddenFiles = !this.showHiddenFiles;
+			localStorage.setItem(SHOW_HIDDEN_FILES_STORAGE_KEY, String(this.showHiddenFiles));
+			this.clearSelection();
+			this.updateVisibleList();
+			this.handelListChange(this.listData);
 		},
 
 		/**

--- a/src/events/events.js
+++ b/src/events/events.js
@@ -27,5 +27,8 @@ const events = {
 	ACTIVE_DROP_UPLOAD: 'activeDropUpload',
 	SHOW_FILES_SIDEBAR: 'showFilesSidebar',
 	HIDE_FILES_SIDEBAR: 'hideFilesSidebar',
+	OPEN_APP_IFRAME: 'openAppIframe',
+	OPEN_APP_LAUNCHER: 'openAppLauncher',
+	CLOSE_APP_IFRAME: 'closeAppIframe',
 };
 export default events;

--- a/src/mixins/app/Business_OpenThirdApp.js
+++ b/src/mixins/app/Business_OpenThirdApp.js
@@ -7,28 +7,26 @@
  * Copyright (c) 2022 by IceWhale, All Rights Reserved.
  */
 
+import events from '@/events/events'
+
 export default {
 	methods: {
 		openAppToNewWindow(appInfo) {
-			this.hasNewTag(appInfo.name) ? this.firstOpenThirdApp(appInfo) : this.openThirdApp(appInfo, true);
+			this.hasNewTag(appInfo.name) ? this.firstOpenThirdApp(appInfo) : this.openThirdApp(appInfo);
 		},
-		openThirdApp(appInfo, isNewWindows) {
+		openThirdApp(appInfo) {
 			this.$messageBus('apps_open', appInfo.name);
 			if (appInfo.hostname !== "" || appInfo.port !== "" || appInfo.index !== "") {
 				const hostIp = appInfo.hostname || this.$baseIp
 				const scheme = appInfo.scheme || 'http'
 				const port = appInfo.port ? `:${appInfo.port}` : ''
-				const url = `${scheme}://${hostIp}${port}${appInfo.index}`
+				const index = appInfo.index || ''
+				const url = `${scheme}://${hostIp}${port}${index}`
 
-				if (isNewWindows) {
-					window.open(url);
-				} else {
-					let html = document.createElement('a');
-					html.href = url;
-					html.rel = 'noreferrer';
-					document.getElementById('app').appendChild(html)
-					html.click();
-				}
+				this.$EventBus.$emit(events.OPEN_APP_IFRAME, {
+					name: appInfo.name,
+					url,
+				})
 			}
 		},
 		async openThirdContainerByAppInfo(appInfo) {
@@ -63,14 +61,7 @@ export default {
 		},
 		firstOpenThirdApp(appInfo) {
 			this.removeIdFromSessionStorage(appInfo.name);
-			let routeUrl = this.$router.resolve({
-				name: 'AppLauncherCheck',
-				path: '/launch',
-				query: {
-					appDetailData: JSON.stringify(appInfo)
-				}
-			});
-			window.open(routeUrl.href, '_blank');
+			this.$EventBus.$emit(events.OPEN_APP_LAUNCHER, appInfo)
 		}
 	}
 }

--- a/src/mixins/app/Business_OpenThirdApp.js
+++ b/src/mixins/app/Business_OpenThirdApp.js
@@ -9,8 +9,19 @@
 
 import events from '@/events/events'
 
+const OPEN_IN_NEW_WINDOW_APP_IDS = new Set([
+	'qbittorrent',
+	'org.icewhale.qbittorrent',
+])
+
 export default {
 	methods: {
+		shouldOpenInNewWindow(appInfo) {
+			return [appInfo.id, appInfo.name]
+				.filter(Boolean)
+				.map(identifier => String(identifier).toLowerCase())
+				.some(identifier => OPEN_IN_NEW_WINDOW_APP_IDS.has(identifier))
+		},
 		openAppToNewWindow(appInfo) {
 			this.hasNewTag(appInfo.name) ? this.firstOpenThirdApp(appInfo) : this.openThirdApp(appInfo);
 		},
@@ -22,6 +33,12 @@ export default {
 				const port = appInfo.port ? `:${appInfo.port}` : ''
 				const index = appInfo.index || ''
 				const url = `${scheme}://${hostIp}${port}${index}`
+
+				if (this.shouldOpenInNewWindow(appInfo)) {
+					window.open(url, '_blank')
+					this.$EventBus.$emit(events.CLOSE_APP_IFRAME)
+					return
+				}
 
 				this.$EventBus.$emit(events.OPEN_APP_IFRAME, {
 					name: appInfo.name,

--- a/src/mixins/file_utils.js
+++ b/src/mixins/file_utils.js
@@ -10,3 +10,15 @@ export const renderSize  = (bytes) => {
     if (i === 0) return `${bytes} ${sizes[i]}`
     return `${parseFloat((bytes / (1024 ** i)).toFixed(2))} ${sizes[i]}`
 }
+
+/**
+ * Filter dot-prefixed files and folders unless hidden entries are enabled.
+ * @param {Array} files
+ * @param {Boolean} showHiddenFiles
+ * @return {Array}
+ */
+export const filterHiddenFiles = (files, showHiddenFiles) => {
+    if (showHiddenFiles) return files
+
+    return files.filter((file) => !file.name.startsWith('.'))
+}

--- a/src/mixins/file_utils.spec.js
+++ b/src/mixins/file_utils.spec.js
@@ -1,5 +1,5 @@
 import { expect, test, describe } from 'vitest'
-import { renderSize } from './file_utils'
+import { filterHiddenFiles, renderSize } from './file_utils'
 
 describe('renderSize', () => {
 	test.each([
@@ -16,5 +16,25 @@ describe('renderSize', () => {
 		[1024**6, '1 EB'],
 	])('format %s bytes as %s', (bytes, formattedSize) => {
 		expect(renderSize(bytes)).toEqual(formattedSize)
+	})
+})
+
+describe('filterHiddenFiles', () => {
+	const files = [
+		{ name: 'visible-file.txt' },
+		{ name: '.hidden-file' },
+		{ name: '.hidden-folder' },
+		{ name: 'file.with-dot.txt' },
+	]
+
+	test('filters dot-prefixed files and folders when disabled', () => {
+		expect(filterHiddenFiles(files, false)).toEqual([
+			{ name: 'visible-file.txt' },
+			{ name: 'file.with-dot.txt' },
+		])
+	})
+
+	test('keeps dot-prefixed files and folders when enabled', () => {
+		expect(filterHiddenFiles(files, true)).toBe(files)
 	})
 })

--- a/src/views/AppLauncherCheck.vue
+++ b/src/views/AppLauncherCheck.vue
@@ -8,7 +8,16 @@
   -->
 <template>
 	<div v-if="isCheckFailed"
-		 class="is-flex is-flex-direction-column is-align-items-center is-justify-content-center is-fullheight">
+			 class="app-launcher-overlay is-flex is-flex-direction-column is-align-items-center is-justify-content-center is-fullheight">
+		<button
+			class="app-launcher-close"
+			type="button"
+			:aria-label="$t('Close')"
+			:title="$t('Close')"
+			@click="close"
+		>
+			<b-icon custom-size="casa-24px" icon="close-outline" pack="casa" />
+		</button>
 		<b-image :key="appDetailData.icon" :src="appDetailData.icon"
 				 :src-fallback="require('@/assets/img/app/default.svg')"
 				 class="is-64x64 icon-shadow" webp-fallback=".jpg"></b-image>
@@ -30,10 +39,17 @@
 
 <script>
 import business_OpenThirdApp from "@/mixins/app/Business_OpenThirdApp";
+import events from '@/events/events'
 
 export default {
 	name: "AppLauncherCheck",
 	mixins: [business_OpenThirdApp],
+	props: {
+		appDetail: {
+			type: Object,
+			default: null,
+		},
+	},
 	data() {
 		return {
 			appDetailData: {
@@ -42,21 +58,40 @@ export default {
 			},
 			status: "pending",
 			timer: null,
-			isCheckFailed: false,
+			isCheckFailed: true,
 			checkCounts: 3,
-			counter: 0
+			counter: 0,
+			isCancelled: false,
 		}
 	},
 
 	async created() {
-		this.appDetailData = JSON.parse(this.$route.query.appDetailData)
-		const startRes = await this.startContainer()
+		if (this.appDetail) {
+			this.appDetailData = this.appDetail
+		} else if (this.$route.query.appDetailData) {
+			this.appDetailData = JSON.parse(this.$route.query.appDetailData)
+		}
+		await this.startContainer()
+		if (this.isCancelled) return
 		this.timer && clearInterval(this.timer)
 		this.timer = setInterval(this.check, 1000)
 		this.check()
 	},
+	beforeDestroy() {
+		this.isCancelled = true
+		this.timer && clearInterval(this.timer)
+	},
 
 	methods: {
+		close() {
+			this.isCancelled = true
+			this.timer && clearInterval(this.timer)
+			if (this.appDetail) {
+				this.$EventBus.$emit(events.CLOSE_APP_IFRAME)
+			} else {
+				this.$router.replace({ name: 'Home' })
+			}
+		},
 		// Get container running state
 		async getContainerState() {
 			try {
@@ -88,8 +123,10 @@ export default {
 		},
 
 		async check() {
+			if (this.isCancelled) return
 			this.counter += 1
 			const isOk = await this.healthCheck()
+			if (this.isCancelled) return
 			if (isOk) {
 				clearInterval(this.timer)
 				this.openThirdApp(this.appDetailData)
@@ -105,9 +142,42 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.app-launcher-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 1000;
+}
+
 .is-fullheight {
 	background: hsla(208, 20%, 12%, 1);
 	height: 100vh;
+}
+
+.app-launcher-close {
+	position: absolute;
+	top: 1rem;
+	right: 1rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.25rem;
+	height: 2.25rem;
+	padding: 0;
+	color: #fff;
+	cursor: pointer;
+	background: transparent;
+	border: 0;
+	border-radius: 0.25rem;
+}
+
+.app-launcher-close:hover,
+.app-launcher-close:focus-visible {
+	background: rgba(255, 255, 255, 0.12);
+}
+
+.app-launcher-close:focus {
+	outline: 2px solid rgba(255, 255, 255, 0.8);
+	outline-offset: 2px;
 }
 
 .position {


### PR DESCRIPTION
## Summary

- restore the UI release-build dependency state
- add dot-file visibility support in the file browser
- open installed apps in an in-page iframe dialog
- hardcode qBittorrent to open in a top-level browser tab because its WebUI does not work correctly in the iframe
- close the CasaOS launch overlay after qBittorrent opens, including the first-launch health-check path

## Why

The iframe provides a better in-app experience for compatible WebUIs, but qBittorrent’s WebUI relies on `window.parent` behavior that is blocked by the cross-origin iframe context. qBittorrent therefore needs a top-level browser context while other apps continue using the iframe.

## Validation

- `pnpm run build` passed
- existing unrelated uncommitted worktree changes were left unstaged
